### PR TITLE
feat(audit-workspace): integrate UI rework, Word preview, PDF report & verdict validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,13 @@
         <java.version>17</java.version>
     </properties>
     <dependencies>
+        <!-- OpenPDF (com.lowagie.text) for server-side audit PDF report generation -->
+        <dependency>
+            <groupId>com.github.librepdf</groupId>
+            <artifactId>openpdf</artifactId>
+            <version>1.3.30</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.springframework.data/spring-data-keyvalue -->
         <dependency>
             <groupId>org.springframework.data</groupId>

--- a/src/app/admin/audit-workspace/audit-workspace.component.html
+++ b/src/app/admin/audit-workspace/audit-workspace.component.html
@@ -402,7 +402,7 @@
       <div class="center-nav">
         <button class="ef-btn" (click)="goToStep(activeStep - 1)" [disabled]="activeStep === 0">← Prev</button>
         <button *ngIf="activeStep < steps.length - 1"
-                class="ef-btn ef-btn--next" 
+                class="ef-btn ef-btn--next"
                 [disabled]="!isStepFullyVerdicted(currentStep)"
                 [title]="!isStepFullyVerdicted(currentStep) ? 'Please provide a verdict for all questions before proceeding' : 'Go to next step'"
                 (click)="goToStep(activeStep + 1)">Next →</button>

--- a/src/app/admin/audit-workspace/audit-workspace.component.html
+++ b/src/app/admin/audit-workspace/audit-workspace.component.html
@@ -59,7 +59,7 @@
   </div>
 
   <!-- ══ 3-PANE COCKPIT ══ -->
-  <div class="ws-cockpit" *ngIf="steps.length > 0">
+  <div class="ws-cockpit" [class.ws-cockpit--rail-collapsed]="isRailCollapsed" *ngIf="steps.length > 0">
 
     <!-- ╞══ LEFT: vertical step rail ══╡ -->
     <aside class="ws-rail">
@@ -113,8 +113,20 @@
       </ol>
     </aside>
 
-    <!-- ╞══ CENTER: per-question cards ══╡ -->
+    <!-- ╞══ CENTER: per-question cards + Findings & Recommendations ══╡ -->
     <section class="ws-center" *ngIf="currentStep">
+      <!-- ✅ FLOATING TOGGLE BUTTON – always visible -->
+      <button class="ws-rail-toggle ws-rail-toggle--floating"
+              (click)="toggleRail()"
+              [title]="isRailCollapsed ? 'Show steps' : 'Hide steps'">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+             stroke-width="2" width="18" height="18" style="display:block;">
+          <line x1="3" y1="6" x2="21" y2="6"/>
+          <line x1="3" y1="12" x2="21" y2="12"/>
+          <line x1="3" y1="18" x2="21" y2="18"/>
+        </svg>
+      </button>
+
       <div class="center-head">
         <div class="center-head__top">
           <span class="center-head__pill">STEP {{ activeStep + 1 }} / {{ steps.length }}</span>
@@ -161,81 +173,212 @@
         </ul>
       </details>
 
-      <div class="qcards">
-        <div class="qcard-empty" *ngIf="currentStepAnswers.length === 0">
-          No customer answers mapped to this step.
+      <!-- ===== SCROLLABLE QUESTION CARDS ===== -->
+      <div class="qcards-scroll">
+        <div class="qcards">
+          <div class="qcard-empty" *ngIf="currentStepAnswers.length === 0">
+            No customer answers mapped to this step.
+          </div>
+
+          <!-- ===== QUESTION CARD LOOP ===== -->
+          <article class="qcard" *ngFor="let a of currentStepAnswers; let i = index"
+                   [class.qcard--compliant]="verdictFor(currentStep.id, a.fieldId) === 'compliant'"
+                   [class.qcard--observation]="verdictFor(currentStep.id, a.fieldId) === 'observation'"
+                   [class.qcard--nc]="verdictFor(currentStep.id, a.fieldId) === 'non-conformity'"
+                   [class.qcard--na]="verdictFor(currentStep.id, a.fieldId) === 'na'">
+            <header class="qcard__head">
+              <span class="qcard__idx">Q{{ i + 1 }}</span>
+              <span class="qcard__label">{{ a.fieldLabel }}</span>
+            </header>
+
+            <div class="qcard__answer">
+              <span class="qcard__answer-lbl">Customer answer</span>
+              <div class="qcard__answer-val">{{ a.answerValue || '—' }}</div>
+            </div>
+
+            <!-- ✅ Evidence chips – avec index correct (commence à 1) -->
+            <div class="qcard__evidence" *ngIf="a.fileMedia || (a.files && a.files.length)">
+              <!-- Fichier principal (fileMedia) -->
+              <ng-container *ngIf="a.fileMedia">
+                <div class="evidence-chip"
+                     (click)="openEvidence({id: a.fileMedia.id, url: a.fileMedia.url, name: a.fileMedia.name}, i + 1, a.fieldLabel)"
+                     role="button" tabindex="0"
+                     (keyup.enter)="openEvidence({id: a.fileMedia.id, url: a.fileMedia.url, name: a.fileMedia.name}, i + 1, a.fieldLabel)">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="11" height="11">
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                    <polyline points="14 2 14 8 20 8"/>
+                  </svg>
+                  <span class="evidence-chip__name">Evidence {{ i + 1 }}</span>
+                  <span [class]="ocrClass(ocrFor(a.fileMedia.id))" [title]="ocrTitle(ocrFor(a.fileMedia.id))">{{ ocrLabel(ocrFor(a.fileMedia.id)) }}</span>
+                  <button class="evidence-chip__btn evidence-chip__btn--retry"
+                          *ngIf="isRetryable(ocrFor(a.fileMedia.id))" (click)="retryOcr(a.fileMedia.id, $event)">Retry</button>
+                </div>
+              </ng-container>
+
+              <!-- Fichiers supplémentaires (files) – avec index calculé selon présence de fileMedia -->
+              <ng-container *ngFor="let f of (a.files || []); let fi = index">
+                <!-- Calcul de l'index : si fileMedia existe, l'index est i + fi + 2, sinon i + fi + 1 -->
+                <ng-container *ngIf="a.fileMedia; else noFileMedia">
+                  <div class="evidence-chip"
+                       (click)="openEvidence({id: f.media ? f.media.id : f.id, url: f.media ? f.media.url : f.url, name: f.media ? f.media.name : f.name}, i + fi + 2, a.fieldLabel)"
+                       role="button" tabindex="0"
+                       (keyup.enter)="openEvidence({id: f.media ? f.media.id : f.id, url: f.media ? f.media.url : f.url, name: f.media ? f.media.name : f.name}, i + fi + 2, a.fieldLabel)">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="11" height="11">
+                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                      <polyline points="14 2 14 8 20 8"/>
+                    </svg>
+                    <span class="evidence-chip__name">Evidence {{ i + fi + 2 }}</span>
+                    <span [class]="ocrClass(ocrFor(f.media ? f.media.id : f.id))" [title]="ocrTitle(ocrFor(f.media ? f.media.id : f.id))">{{ ocrLabel(ocrFor(f.media ? f.media.id : f.id)) }}</span>
+                    <button class="evidence-chip__btn evidence-chip__btn--retry"
+                            *ngIf="isRetryable(ocrFor(f.media ? f.media.id : f.id))" (click)="retryOcr(f.media ? f.media.id : f.id, $event)">Retry</button>
+                  </div>
+                </ng-container>
+                <ng-template #noFileMedia>
+                  <div class="evidence-chip"
+                       (click)="openEvidence({id: f.media ? f.media.id : f.id, url: f.media ? f.media.url : f.url, name: f.media ? f.media.name : f.name}, i + fi + 1, a.fieldLabel)"
+                       role="button" tabindex="0"
+                       (keyup.enter)="openEvidence({id: f.media ? f.media.id : f.id, url: f.media ? f.media.url : f.url, name: f.media ? f.media.name : f.name}, i + fi + 1, a.fieldLabel)">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="11" height="11">
+                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                      <polyline points="14 2 14 8 20 8"/>
+                    </svg>
+                    <span class="evidence-chip__name">Evidence {{ i + fi + 1 }}</span>
+                    <span [class]="ocrClass(ocrFor(f.media ? f.media.id : f.id))" [title]="ocrTitle(ocrFor(f.media ? f.media.id : f.id))">{{ ocrLabel(ocrFor(f.media ? f.media.id : f.id)) }}</span>
+                    <button class="evidence-chip__btn evidence-chip__btn--retry"
+                            *ngIf="isRetryable(ocrFor(f.media ? f.media.id : f.id))" (click)="retryOcr(f.media ? f.media.id : f.id, $event)">Retry</button>
+                  </div>
+                </ng-template>
+              </ng-container>
+            </div>
+
+            <!-- Verdict -->
+            <div class="verdict-row" *ngIf="request?.status !== 'COMPLETED'">
+              <span class="verdict-row__lbl">Verdict</span>
+              <button type="button" class="vchip vchip--compliant"
+                      [class.vchip--on]="verdictFor(currentStep.id, a.fieldId) === 'compliant'"
+                      (click)="setVerdict(currentStep.id, a.fieldId, 'compliant')">✓ Compliant</button>
+              <button type="button" class="vchip vchip--observation"
+                      [class.vchip--on]="verdictFor(currentStep.id, a.fieldId) === 'observation'"
+                      (click)="setVerdict(currentStep.id, a.fieldId, 'observation')">⚠ Observation</button>
+              <button type="button" class="vchip vchip--nc"
+                      [class.vchip--on]="verdictFor(currentStep.id, a.fieldId) === 'non-conformity'"
+                      (click)="setVerdict(currentStep.id, a.fieldId, 'non-conformity')">✗ Non-conformity</button>
+              <button type="button" class="vchip vchip--na"
+                      [class.vchip--on]="verdictFor(currentStep.id, a.fieldId) === 'na'"
+                      (click)="setVerdict(currentStep.id, a.fieldId, 'na')">N/A</button>
+            </div>
+            <div class="verdict-row verdict-row--readonly" *ngIf="request?.status === 'COMPLETED' && verdictFor(currentStep.id, a.fieldId) as v">
+              <span class="verdict-row__lbl">Verdict</span>
+              <span class="vchip vchip--on" [ngClass]="'vchip--' + v">{{ v }}</span>
+            </div>
+          </article>
+        </div>
+      </div>
+
+      <!-- ===== FINDINGS & RECOMMENDATIONS (always visible) ===== -->
+      <div class="ws-deck-bottom">
+        <!-- Findings -->
+        <div class="deck-section">
+          <div class="deck-section__head">
+            <span class="deck-section__title">Findings</span>
+            <button class="deck-section__add" (click)="addFinding()"
+                    [disabled]="request?.status === 'COMPLETED'">+ Add</button>
+          </div>
+          <div class="deck-empty" *ngIf="currentFindings().length === 0">
+            No findings recorded for this step.
+          </div>
+          <div class="finding" *ngFor="let f of currentFindings()">
+            <div class="finding__head">
+              <select class="finding__sev" [value]="f.severity"
+                      (change)="updateFindingSeverity(f.id, $any($event.target).value)"
+                      [disabled]="request?.status === 'COMPLETED'">
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="critical">Critical</option>
+              </select>
+              <span class="finding__sev-dot" [ngClass]="'finding__sev-dot--' + f.severity"></span>
+              <button class="finding__del" (click)="removeFinding(f.id)"
+                      [disabled]="request?.status === 'COMPLETED'"
+                      title="Remove">×</button>
+            </div>
+            <textarea class="finding__text"
+                      [value]="f.description"
+                      (input)="updateFindingText(f.id, $any($event.target).value)"
+                      [disabled]="request?.status === 'COMPLETED'"
+                      placeholder="Describe the finding, clause reference, and evidence cited…"
+                      rows="4"></textarea>
+
+            <!-- RICS clauses -->
+            <div class="clause-row">
+              <span class="clause-chip" *ngFor="let c of (f.clauses || [])"
+                    [title]="c.requirement || c.ruleId">
+                <strong>{{ c.ruleId }}</strong>
+                <span class="clause-chip__title" *ngIf="c.shortTitle"> · {{ c.shortTitle }}</span>
+                <button class="clause-chip__del" *ngIf="request?.status !== 'COMPLETED'"
+                        (click)="detachClause(f.id, c.ruleId)" title="Remove">×</button>
+              </span>
+              <button class="clause-add-btn" *ngIf="request?.status !== 'COMPLETED'"
+                      (click)="openClausePicker(f.id)">+ Clause</button>
+            </div>
+
+            <!-- Clause picker -->
+            <div class="clause-picker" *ngIf="pickerOpenFor === f.id">
+              <div class="clause-picker__head">
+                <input type="text" class="clause-picker__input"
+                       [(ngModel)]="pickerQuery"
+                       (input)="onPickerQueryChange()"
+                       placeholder="Search RICS clauses (e.g. governance, transparency, oversight)…"
+                       autofocus/>
+                <button class="clause-picker__close" (click)="closeClausePicker()" title="Close">×</button>
+              </div>
+              <div class="clause-picker__body">
+                <div class="clause-picker__loading" *ngIf="pickerLoading">Searching…</div>
+                <div class="clause-picker__empty"
+                     *ngIf="!pickerLoading && pickerQuery.trim().length >= 3 && pickerResults.length === 0">
+                  No matching clauses.
+                </div>
+                <div class="clause-picker__empty"
+                     *ngIf="!pickerLoading && pickerQuery.trim().length < 3">
+                  Type at least 3 characters.
+                </div>
+                <button class="clause-result" *ngFor="let r of pickerResults"
+                        (click)="attachClause(f.id, r); closeClausePicker()">
+                  <div class="clause-result__head">
+                    <strong>{{ r.rule_id }}</strong>
+                    <span class="clause-result__section" *ngIf="r.payload.section">§{{ r.payload.section }}</span>
+                    <span class="clause-result__score">{{ (r.score * 100).toFixed(0) }}%</span>
+                  </div>
+                  <div class="clause-result__title" *ngIf="r.payload.short_title">{{ r.payload.short_title }}</div>
+                  <div class="clause-result__req" *ngIf="r.payload.requirement_text">{{ r.payload.requirement_text }}</div>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
 
-        <article class="qcard" *ngFor="let a of currentStepAnswers; let i = index"
-                 [class.qcard--compliant]="verdictFor(currentStep.id, a.fieldId) === 'compliant'"
-                 [class.qcard--observation]="verdictFor(currentStep.id, a.fieldId) === 'observation'"
-                 [class.qcard--nc]="verdictFor(currentStep.id, a.fieldId) === 'non-conformity'"
-                 [class.qcard--na]="verdictFor(currentStep.id, a.fieldId) === 'na'">
-          <header class="qcard__head">
-            <span class="qcard__idx">Q{{ i + 1 }}</span>
-            <span class="qcard__label">{{ a.fieldLabel }}</span>
-          </header>
-
-          <div class="qcard__answer">
-            <span class="qcard__answer-lbl">Customer answer</span>
-            <div class="qcard__answer-val">{{ a.answerValue || '—' }}</div>
+        <!-- Recommendations -->
+        <div class="deck-section">
+          <div class="deck-section__head">
+            <span class="deck-section__title">Recommendations</span>
+            <button class="deck-section__add" (click)="addRecommendation()"
+                    [disabled]="request?.status === 'COMPLETED'">+ Add</button>
           </div>
-
-          <!-- Evidence chips -->
-          <div class="qcard__evidence" *ngIf="a.fileMedia || (a.files && a.files.length)">
-            <ng-container *ngIf="a.fileMedia as fm">
-              <div class="evidence-chip"
-                   (click)="openEvidence({id: fm.id, url: fm.url, name: fm.name}, 1, a.fieldLabel)"
-                   role="button" tabindex="0"
-                   (keyup.enter)="openEvidence({id: fm.id, url: fm.url, name: fm.name}, 1, a.fieldLabel)">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="11" height="11">
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-                  <polyline points="14 2 14 8 20 8"/>
-                </svg>
-                <span class="evidence-chip__name" [title]="displayName(fm.name, 1)">{{ displayName(fm.name, 1) }}</span>
-                <span [class]="ocrClass(ocrFor(fm.id))" [title]="ocrTitle(ocrFor(fm.id))">{{ ocrLabel(ocrFor(fm.id)) }}</span>
-                <button class="evidence-chip__btn evidence-chip__btn--retry"
-                        *ngIf="isRetryable(ocrFor(fm.id))" (click)="retryOcr(fm.id, $event)">Retry</button>
-              </div>
-            </ng-container>
-            <ng-container *ngFor="let f of (a.files || []); let i = index">
-              <div class="evidence-chip"
-                   (click)="openEvidence({id: f.media.id, url: f.media.url, name: f.media.name}, a.fileMedia ? i + 2 : i + 1, a.fieldLabel)"
-                   role="button" tabindex="0"
-                   (keyup.enter)="openEvidence({id: f.media.id, url: f.media.url, name: f.media.name}, a.fileMedia ? i + 2 : i + 1, a.fieldLabel)">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="11" height="11">
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-                  <polyline points="14 2 14 8 20 8"/>
-                </svg>
-                <span class="evidence-chip__name" [title]="displayName(f.media.name, a.fileMedia ? i + 2 : i + 1)">{{ displayName(f.media.name, a.fileMedia ? i + 2 : i + 1) }}</span>
-                <span [class]="ocrClass(ocrFor(f.media.id))" [title]="ocrTitle(ocrFor(f.media.id))">{{ ocrLabel(ocrFor(f.media.id)) }}</span>
-                <button class="evidence-chip__btn evidence-chip__btn--retry"
-                        *ngIf="isRetryable(ocrFor(f.media.id))" (click)="retryOcr(f.media.id, $event)">Retry</button>
-              </div>
-            </ng-container>
+          <div class="deck-empty" *ngIf="currentRecs().length === 0">
+            No recommendations yet.
           </div>
-
-          <!-- Per-question verdict -->
-          <div class="verdict-row" *ngIf="request?.status !== 'COMPLETED'">
-            <span class="verdict-row__lbl">Verdict</span>
-            <button type="button" class="vchip vchip--compliant"
-                    [class.vchip--on]="verdictFor(currentStep.id, a.fieldId) === 'compliant'"
-                    (click)="setVerdict(currentStep.id, a.fieldId, 'compliant')">✓ Compliant</button>
-            <button type="button" class="vchip vchip--observation"
-                    [class.vchip--on]="verdictFor(currentStep.id, a.fieldId) === 'observation'"
-                    (click)="setVerdict(currentStep.id, a.fieldId, 'observation')">⚠ Observation</button>
-            <button type="button" class="vchip vchip--nc"
-                    [class.vchip--on]="verdictFor(currentStep.id, a.fieldId) === 'non-conformity'"
-                    (click)="setVerdict(currentStep.id, a.fieldId, 'non-conformity')">✗ Non-conformity</button>
-            <button type="button" class="vchip vchip--na"
-                    [class.vchip--on]="verdictFor(currentStep.id, a.fieldId) === 'na'"
-                    (click)="setVerdict(currentStep.id, a.fieldId, 'na')">N/A</button>
+          <div class="rec" *ngFor="let r of currentRecs()">
+            <textarea class="rec__text"
+                      [value]="r.description"
+                      (input)="updateRecText(r.id, $any($event.target).value)"
+                      [disabled]="request?.status === 'COMPLETED'"
+                      placeholder="Recommend a corrective action, owner and timeframe…"
+                      rows="4"></textarea>
+            <button class="rec__del" (click)="removeRecommendation(r.id)"
+                    [disabled]="request?.status === 'COMPLETED'"
+                    title="Remove">×</button>
           </div>
-          <div class="verdict-row verdict-row--readonly" *ngIf="request?.status === 'COMPLETED' && verdictFor(currentStep.id, a.fieldId) as v">
-            <span class="verdict-row__lbl">Verdict</span>
-            <span class="vchip vchip--on" [ngClass]="'vchip--' + v">{{ v }}</span>
-          </div>
-        </article>
+        </div>
       </div>
 
       <!-- Step nav -->
@@ -256,112 +399,8 @@
       </div>
     </section>
 
-    <!-- ╞══ RIGHT: auditor deck ══╡ -->
+    <!-- ╞══ RIGHT: Step note only ══╡ -->
     <aside class="ws-deck" *ngIf="currentStep">
-      <!-- Findings -->
-      <div class="deck-section">
-        <div class="deck-section__head">
-          <span class="deck-section__title">Findings</span>
-          <button class="deck-section__add" (click)="addFinding()"
-                  [disabled]="request?.status === 'COMPLETED'">+ Add</button>
-        </div>
-        <div class="deck-empty" *ngIf="currentFindings().length === 0">
-          No findings recorded for this step.
-        </div>
-        <div class="finding" *ngFor="let f of currentFindings()">
-          <div class="finding__head">
-            <select class="finding__sev" [value]="f.severity"
-                    (change)="updateFindingSeverity(f.id, $any($event.target).value)"
-                    [disabled]="request?.status === 'COMPLETED'">
-              <option value="low">Low</option>
-              <option value="medium">Medium</option>
-              <option value="high">High</option>
-              <option value="critical">Critical</option>
-            </select>
-            <span class="finding__sev-dot" [ngClass]="'finding__sev-dot--' + f.severity"></span>
-            <button class="finding__del" (click)="removeFinding(f.id)"
-                    [disabled]="request?.status === 'COMPLETED'"
-                    title="Remove">×</button>
-          </div>
-          <textarea class="finding__text"
-                    [value]="f.description"
-                    (input)="updateFindingText(f.id, $any($event.target).value)"
-                    [disabled]="request?.status === 'COMPLETED'"
-                    placeholder="Describe the finding, clause reference, and evidence cited…"
-                    rows="4"></textarea>
-
-          <!-- Phase 4: RICS clauses attached to this finding -->
-          <div class="clause-row">
-            <span class="clause-chip" *ngFor="let c of (f.clauses || [])"
-                  [title]="c.requirement || c.ruleId">
-              <strong>{{ c.ruleId }}</strong>
-              <span class="clause-chip__title" *ngIf="c.shortTitle"> · {{ c.shortTitle }}</span>
-              <button class="clause-chip__del" *ngIf="request?.status !== 'COMPLETED'"
-                      (click)="detachClause(f.id, c.ruleId)" title="Remove">×</button>
-            </span>
-            <button class="clause-add-btn" *ngIf="request?.status !== 'COMPLETED'"
-                    (click)="openClausePicker(f.id)">+ Clause</button>
-          </div>
-
-          <!-- Phase 4: inline picker popover -->
-          <div class="clause-picker" *ngIf="pickerOpenFor === f.id">
-            <div class="clause-picker__head">
-              <input type="text" class="clause-picker__input"
-                     [(ngModel)]="pickerQuery"
-                     (input)="onPickerQueryChange()"
-                     placeholder="Search RICS clauses (e.g. governance, transparency, oversight)…"
-                     autofocus/>
-              <button class="clause-picker__close" (click)="closeClausePicker()" title="Close">×</button>
-            </div>
-            <div class="clause-picker__body">
-              <div class="clause-picker__loading" *ngIf="pickerLoading">Searching…</div>
-              <div class="clause-picker__empty"
-                   *ngIf="!pickerLoading && pickerQuery.trim().length >= 3 && pickerResults.length === 0">
-                No matching clauses.
-              </div>
-              <div class="clause-picker__empty"
-                   *ngIf="!pickerLoading && pickerQuery.trim().length < 3">
-                Type at least 3 characters.
-              </div>
-              <button class="clause-result" *ngFor="let r of pickerResults"
-                      (click)="attachClause(f.id, r); closeClausePicker()">
-                <div class="clause-result__head">
-                  <strong>{{ r.rule_id }}</strong>
-                  <span class="clause-result__section" *ngIf="r.payload.section">§{{ r.payload.section }}</span>
-                  <span class="clause-result__score">{{ (r.score * 100).toFixed(0) }}%</span>
-                </div>
-                <div class="clause-result__title" *ngIf="r.payload.short_title">{{ r.payload.short_title }}</div>
-                <div class="clause-result__req" *ngIf="r.payload.requirement_text">{{ r.payload.requirement_text }}</div>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Recommendations -->
-      <div class="deck-section">
-        <div class="deck-section__head">
-          <span class="deck-section__title">Recommendations</span>
-          <button class="deck-section__add" (click)="addRecommendation()"
-                  [disabled]="request?.status === 'COMPLETED'">+ Add</button>
-        </div>
-        <div class="deck-empty" *ngIf="currentRecs().length === 0">
-          No recommendations yet.
-        </div>
-        <div class="rec" *ngFor="let r of currentRecs()">
-          <textarea class="rec__text"
-                    [value]="r.description"
-                    (input)="updateRecText(r.id, $any($event.target).value)"
-                    [disabled]="request?.status === 'COMPLETED'"
-                    placeholder="Recommend a corrective action, owner and timeframe…"
-                    rows="4"></textarea>
-          <button class="rec__del" (click)="removeRecommendation(r.id)"
-                  [disabled]="request?.status === 'COMPLETED'"
-                  title="Remove">×</button>
-        </div>
-      </div>
-
-      <!-- Step note -->
       <div class="deck-section">
         <div class="deck-section__head">
           <span class="deck-section__title">Step note</span>
@@ -449,12 +488,31 @@
         <div class="file-loading" *ngIf="drawerLoading">
           <div class="loader"></div><span>Loading…</span>
         </div>
+        <!-- Image -->
         <img *ngIf="!drawerLoading && drawerBlobUrl && isImage(drawerMedia.name)"
              [src]="drawerBlobUrl" [alt]="drawerMedia.name" class="ws-drawer__img"/>
-        <iframe *ngIf="!drawerLoading && drawerBlobUrl && !isImage(drawerMedia.name)"
-                [src]="drawerBlobUrl" class="ws-drawer__iframe">
-          <p>Your browser cannot display this file. <a [href]="drawerBlobUrl" target="_blank">Open in new tab</a></p>
-        </iframe>
+
+        <!-- ✅ Utilisation de <object> à la place de l'iframe pour contourner X-Frame-Options -->
+        <object *ngIf="!drawerLoading && drawerBlobUrl && !isImage(drawerMedia.name)"
+                [data]="drawerBlobUrl"
+                type="application/pdf"
+                class="ws-drawer__object"
+                style="width:100%;height:100%;border:none;min-height:400px;">
+          <p>Votre navigateur ne peut pas afficher ce PDF. <a [href]="drawerBlobUrl" target="_blank">Télécharger</a></p>
+        </object>
+
+        <!-- Fallback lorsque drawerBlobUrl est null -->
+        <div *ngIf="!drawerLoading && !drawerBlobUrl" class="ws-drawer__empty">
+          <svg *ngIf="isOfficeDoc(drawerMedia.name)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="40" height="40">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+            <polyline points="14 2 14 8 20 8"/>
+          </svg>
+          <p *ngIf="isOfficeDoc(drawerMedia.name)">
+            Preview not available.
+            <a [href]="getFileUrl(drawerMedia.url)" target="_blank">Download the file</a>
+          </p>
+          <p *ngIf="!isOfficeDoc(drawerMedia.name)">Preview not available.</p>
+        </div>
       </ng-container>
 
       <!-- OCR tab -->

--- a/src/app/admin/audit-workspace/audit-workspace.component.html
+++ b/src/app/admin/audit-workspace/audit-workspace.component.html
@@ -406,7 +406,11 @@
 
         <!-- Mid-audit: advance to the next step -->
         <button *ngIf="activeStep < steps.length - 1"
-                class="ef-btn ef-btn--next" (click)="goToStep(activeStep + 1)">Next →</button>
+                class="ef-btn ef-btn--next" 
+                [disabled]="!isStepFullyVerdicted(currentStep)"
+                [title]="!isStepFullyVerdicted(currentStep) ? 'Please provide a verdict for all questions before proceeding' : 'Go to next step'"
+
+                (click)="goToStep(activeStep + 1)">Next →</button>
 
         <!-- Last step: complete/submit the audit -->
         <button *ngIf="activeStep >= steps.length - 1"

--- a/src/app/admin/audit-workspace/audit-workspace.component.html
+++ b/src/app/admin/audit-workspace/audit-workspace.component.html
@@ -52,6 +52,15 @@
         </button>
       </ng-container>
 
+      <!-- Export the audit PDF report (enabled once completed & all steps saved) -->
+      <button class="ws-btn"
+              [class.ws-btn--complete]="request?.status === 'COMPLETED' && allStepsSaved"
+              [disabled]="!(request?.status === 'COMPLETED' && allStepsSaved) || isExporting"
+              (click)="exportReport()">
+        <span class="mini-spin" *ngIf="isExporting"></span>
+        {{ isExporting ? 'Generating…' : 'Export PDF' }}
+      </button>
+
       <div class="ws-completed-badge" *ngIf="request?.status === 'COMPLETED'">
         ✓ Audit Completed
       </div>
@@ -275,7 +284,8 @@
         </div>
       </div>
 
-      <!-- ===== FINDINGS & RECOMMENDATIONS (always visible) ===== -->
+      <!-- ===== FINDINGS & RECOMMENDATIONS (collapsible bottom drawer) ===== -->
+      <div class="ws-deck-bottom-wrapper" [class.collapsed]="!bottomDeckExpanded">
       <div class="ws-deck-bottom">
         <!-- Findings -->
         <div class="deck-section">
@@ -379,6 +389,15 @@
                     title="Remove">×</button>
           </div>
         </div>
+      </div>
+      </div>
+
+      <!-- Bottom toggle button (centered) -->
+      <div class="bottom-toggle-wrapper">
+        <button class="bottom-toggle-btn" (click)="toggleBottomDeck()">
+          <span class="btn-label">Findings & Recommendations</span>
+          <span class="btn-icon">{{ bottomDeckExpanded ? '▲' : '▼' }}</span>
+        </button>
       </div>
 
       <!-- Step nav -->

--- a/src/app/admin/audit-workspace/audit-workspace.component.html
+++ b/src/app/admin/audit-workspace/audit-workspace.component.html
@@ -402,7 +402,10 @@
       <div class="center-nav">
         <button class="ef-btn" (click)="goToStep(activeStep - 1)" [disabled]="activeStep === 0">← Prev</button>
         <button *ngIf="activeStep < steps.length - 1"
-                class="ef-btn ef-btn--next" (click)="goToStep(activeStep + 1)">Next →</button>
+                class="ef-btn ef-btn--next" 
+                [disabled]="!isStepFullyVerdicted(currentStep)"
+                [title]="!isStepFullyVerdicted(currentStep) ? 'Please provide a verdict for all questions before proceeding' : 'Go to next step'"
+                (click)="goToStep(activeStep + 1)">Next →</button>
         <button *ngIf="activeStep >= steps.length - 1"
                 class="ef-btn ef-btn--complete" (click)="submitAudit()"
                 [disabled]="isCompleting || request?.status === 'COMPLETED'">

--- a/src/app/admin/audit-workspace/audit-workspace.component.html
+++ b/src/app/admin/audit-workspace/audit-workspace.component.html
@@ -51,13 +51,11 @@
           {{ isCompleting ? 'Submitting…' : 'Submit Audit' }}
         </button>
       </ng-container>
-
-      <!-- Export the audit PDF report (enabled once completed & all steps saved) -->
       <button class="ws-btn"
-              [class.ws-btn--complete]="request?.status === 'COMPLETED' && allStepsSaved"
-              [disabled]="!(request?.status === 'COMPLETED' && allStepsSaved) || isExporting"
-              (click)="exportReport()">
-        <span class="mini-spin" *ngIf="isExporting"></span>
+        [class.ws-btn--complete]="request?.status === 'COMPLETED' && allStepsSaved"
+        [disabled]="! (request?.status === 'COMPLETED' && allStepsSaved) || isExporting"
+        (click)="exportReport()">
+      <span class="mini-spin" *ngIf="isExporting"></span>
         {{ isExporting ? 'Generating…' : 'Export PDF' }}
       </button>
 
@@ -284,112 +282,112 @@
         </div>
       </div>
 
-      <!-- ===== FINDINGS & RECOMMENDATIONS (collapsible bottom drawer) ===== -->
+      <!-- ===== FINDINGS & RECOMMENDATIONS (bottom drawer with toggle) ===== -->
       <div class="ws-deck-bottom-wrapper" [class.collapsed]="!bottomDeckExpanded">
-      <div class="ws-deck-bottom">
-        <!-- Findings -->
-        <div class="deck-section">
-          <div class="deck-section__head">
-            <span class="deck-section__title">Findings</span>
-            <button class="deck-section__add" (click)="addFinding()"
-                    [disabled]="request?.status === 'COMPLETED'">+ Add</button>
+        <div class="ws-deck-bottom">
+          <!-- Findings -->
+          <div class="deck-section">
+            <div class="deck-section__head">
+              <span class="deck-section__title">Findings</span>
+              <button class="deck-section__add" (click)="addFinding()"
+                      [disabled]="request?.status === 'COMPLETED'">+ Add</button>
+            </div>
+            <div class="deck-empty" *ngIf="currentFindings().length === 0">
+              No findings recorded for this step.
+            </div>
+            <div class="finding" *ngFor="let f of currentFindings()">
+              <div class="finding__head">
+                <select class="finding__sev" [value]="f.severity"
+                        (change)="updateFindingSeverity(f.id, $any($event.target).value)"
+                        [disabled]="request?.status === 'COMPLETED'">
+                  <option value="low">Low</option>
+                  <option value="medium">Medium</option>
+                  <option value="high">High</option>
+                  <option value="critical">Critical</option>
+                </select>
+                <span class="finding__sev-dot" [ngClass]="'finding__sev-dot--' + f.severity"></span>
+                <button class="finding__del" (click)="removeFinding(f.id)"
+                        [disabled]="request?.status === 'COMPLETED'"
+                        title="Remove">×</button>
+              </div>
+              <textarea class="finding__text"
+                        [value]="f.description"
+                        (input)="updateFindingText(f.id, $any($event.target).value)"
+                        [disabled]="request?.status === 'COMPLETED'"
+                        placeholder="Describe the finding, clause reference, and evidence cited…"
+                        rows="4"></textarea>
+
+              <!-- RICS clauses -->
+              <div class="clause-row">
+                <span class="clause-chip" *ngFor="let c of (f.clauses || [])"
+                      [title]="c.requirement || c.ruleId">
+                  <strong>{{ c.ruleId }}</strong>
+                  <span class="clause-chip__title" *ngIf="c.shortTitle"> · {{ c.shortTitle }}</span>
+                  <button class="clause-chip__del" *ngIf="request?.status !== 'COMPLETED'"
+                          (click)="detachClause(f.id, c.ruleId)" title="Remove">×</button>
+                </span>
+                <button class="clause-add-btn" *ngIf="request?.status !== 'COMPLETED'"
+                        (click)="openClausePicker(f.id)">+ Clause</button>
+              </div>
+
+              <!-- Clause picker -->
+              <div class="clause-picker" *ngIf="pickerOpenFor === f.id">
+                <div class="clause-picker__head">
+                  <input type="text" class="clause-picker__input"
+                         [(ngModel)]="pickerQuery"
+                         (input)="onPickerQueryChange()"
+                         placeholder="Search RICS clauses (e.g. governance, transparency, oversight)…"
+                         autofocus/>
+                  <button class="clause-picker__close" (click)="closeClausePicker()" title="Close">×</button>
+                </div>
+                <div class="clause-picker__body">
+                  <div class="clause-picker__loading" *ngIf="pickerLoading">Searching…</div>
+                  <div class="clause-picker__empty"
+                       *ngIf="!pickerLoading && pickerQuery.trim().length >= 3 && pickerResults.length === 0">
+                    No matching clauses.
+                  </div>
+                  <div class="clause-picker__empty"
+                       *ngIf="!pickerLoading && pickerQuery.trim().length < 3">
+                    Type at least 3 characters.
+                  </div>
+                  <button class="clause-result" *ngFor="let r of pickerResults"
+                          (click)="attachClause(f.id, r); closeClausePicker()">
+                    <div class="clause-result__head">
+                      <strong>{{ r.rule_id }}</strong>
+                      <span class="clause-result__section" *ngIf="r.payload.section">§{{ r.payload.section }}</span>
+                      <span class="clause-result__score">{{ (r.score * 100).toFixed(0) }}%</span>
+                    </div>
+                    <div class="clause-result__title" *ngIf="r.payload.short_title">{{ r.payload.short_title }}</div>
+                    <div class="clause-result__req" *ngIf="r.payload.requirement_text">{{ r.payload.requirement_text }}</div>
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="deck-empty" *ngIf="currentFindings().length === 0">
-            No findings recorded for this step.
-          </div>
-          <div class="finding" *ngFor="let f of currentFindings()">
-            <div class="finding__head">
-              <select class="finding__sev" [value]="f.severity"
-                      (change)="updateFindingSeverity(f.id, $any($event.target).value)"
-                      [disabled]="request?.status === 'COMPLETED'">
-                <option value="low">Low</option>
-                <option value="medium">Medium</option>
-                <option value="high">High</option>
-                <option value="critical">Critical</option>
-              </select>
-              <span class="finding__sev-dot" [ngClass]="'finding__sev-dot--' + f.severity"></span>
-              <button class="finding__del" (click)="removeFinding(f.id)"
+
+          <!-- Recommendations -->
+          <div class="deck-section">
+            <div class="deck-section__head">
+              <span class="deck-section__title">Recommendations</span>
+              <button class="deck-section__add" (click)="addRecommendation()"
+                      [disabled]="request?.status === 'COMPLETED'">+ Add</button>
+            </div>
+            <div class="deck-empty" *ngIf="currentRecs().length === 0">
+              No recommendations yet.
+            </div>
+            <div class="rec" *ngFor="let r of currentRecs()">
+              <textarea class="rec__text"
+                        [value]="r.description"
+                        (input)="updateRecText(r.id, $any($event.target).value)"
+                        [disabled]="request?.status === 'COMPLETED'"
+                        placeholder="Recommend a corrective action, owner and timeframe…"
+                        rows="4"></textarea>
+              <button class="rec__del" (click)="removeRecommendation(r.id)"
                       [disabled]="request?.status === 'COMPLETED'"
                       title="Remove">×</button>
             </div>
-            <textarea class="finding__text"
-                      [value]="f.description"
-                      (input)="updateFindingText(f.id, $any($event.target).value)"
-                      [disabled]="request?.status === 'COMPLETED'"
-                      placeholder="Describe the finding, clause reference, and evidence cited…"
-                      rows="4"></textarea>
-
-            <!-- RICS clauses -->
-            <div class="clause-row">
-              <span class="clause-chip" *ngFor="let c of (f.clauses || [])"
-                    [title]="c.requirement || c.ruleId">
-                <strong>{{ c.ruleId }}</strong>
-                <span class="clause-chip__title" *ngIf="c.shortTitle"> · {{ c.shortTitle }}</span>
-                <button class="clause-chip__del" *ngIf="request?.status !== 'COMPLETED'"
-                        (click)="detachClause(f.id, c.ruleId)" title="Remove">×</button>
-              </span>
-              <button class="clause-add-btn" *ngIf="request?.status !== 'COMPLETED'"
-                      (click)="openClausePicker(f.id)">+ Clause</button>
-            </div>
-
-            <!-- Clause picker -->
-            <div class="clause-picker" *ngIf="pickerOpenFor === f.id">
-              <div class="clause-picker__head">
-                <input type="text" class="clause-picker__input"
-                       [(ngModel)]="pickerQuery"
-                       (input)="onPickerQueryChange()"
-                       placeholder="Search RICS clauses (e.g. governance, transparency, oversight)…"
-                       autofocus/>
-                <button class="clause-picker__close" (click)="closeClausePicker()" title="Close">×</button>
-              </div>
-              <div class="clause-picker__body">
-                <div class="clause-picker__loading" *ngIf="pickerLoading">Searching…</div>
-                <div class="clause-picker__empty"
-                     *ngIf="!pickerLoading && pickerQuery.trim().length >= 3 && pickerResults.length === 0">
-                  No matching clauses.
-                </div>
-                <div class="clause-picker__empty"
-                     *ngIf="!pickerLoading && pickerQuery.trim().length < 3">
-                  Type at least 3 characters.
-                </div>
-                <button class="clause-result" *ngFor="let r of pickerResults"
-                        (click)="attachClause(f.id, r); closeClausePicker()">
-                  <div class="clause-result__head">
-                    <strong>{{ r.rule_id }}</strong>
-                    <span class="clause-result__section" *ngIf="r.payload.section">§{{ r.payload.section }}</span>
-                    <span class="clause-result__score">{{ (r.score * 100).toFixed(0) }}%</span>
-                  </div>
-                  <div class="clause-result__title" *ngIf="r.payload.short_title">{{ r.payload.short_title }}</div>
-                  <div class="clause-result__req" *ngIf="r.payload.requirement_text">{{ r.payload.requirement_text }}</div>
-                </button>
-              </div>
-            </div>
           </div>
         </div>
-
-        <!-- Recommendations -->
-        <div class="deck-section">
-          <div class="deck-section__head">
-            <span class="deck-section__title">Recommendations</span>
-            <button class="deck-section__add" (click)="addRecommendation()"
-                    [disabled]="request?.status === 'COMPLETED'">+ Add</button>
-          </div>
-          <div class="deck-empty" *ngIf="currentRecs().length === 0">
-            No recommendations yet.
-          </div>
-          <div class="rec" *ngFor="let r of currentRecs()">
-            <textarea class="rec__text"
-                      [value]="r.description"
-                      (input)="updateRecText(r.id, $any($event.target).value)"
-                      [disabled]="request?.status === 'COMPLETED'"
-                      placeholder="Recommend a corrective action, owner and timeframe…"
-                      rows="4"></textarea>
-            <button class="rec__del" (click)="removeRecommendation(r.id)"
-                    [disabled]="request?.status === 'COMPLETED'"
-                    title="Remove">×</button>
-          </div>
-        </div>
-      </div>
       </div>
 
       <!-- Bottom toggle button (centered) -->
@@ -403,16 +401,8 @@
       <!-- Step nav -->
       <div class="center-nav">
         <button class="ef-btn" (click)="goToStep(activeStep - 1)" [disabled]="activeStep === 0">← Prev</button>
-
-        <!-- Mid-audit: advance to the next step -->
         <button *ngIf="activeStep < steps.length - 1"
-                class="ef-btn ef-btn--next" 
-                [disabled]="!isStepFullyVerdicted(currentStep)"
-                [title]="!isStepFullyVerdicted(currentStep) ? 'Please provide a verdict for all questions before proceeding' : 'Go to next step'"
-
-                (click)="goToStep(activeStep + 1)">Next →</button>
-
-        <!-- Last step: complete/submit the audit -->
+                class="ef-btn ef-btn--next" (click)="goToStep(activeStep + 1)">Next →</button>
         <button *ngIf="activeStep >= steps.length - 1"
                 class="ef-btn ef-btn--complete" (click)="submitAudit()"
                 [disabled]="isCompleting || request?.status === 'COMPLETED'">

--- a/src/app/admin/audit-workspace/audit-workspace.component.scss
+++ b/src/app/admin/audit-workspace/audit-workspace.component.scss
@@ -153,10 +153,7 @@
   font-family: inherit;
   transition: background .15s;
 
-  // Hide label by default — only active step shows its name to keep the
-  // stepper compact regardless of step count. Hover reveals via tooltip.
   .step-label-inline { display: none; }
-
   &:hover { background: rgb(var(--fg-rgb) / .04); }
 
   &--active {
@@ -217,415 +214,425 @@
   &--done { background: rgb(var(--success-rgb)); }
 }
 
-// ═══ BODY (2 columns) ════════════════════════════════════════
-.ws-body {
-  display: flex;
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-  gap: 0;
-}
-
-.ws-col {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  min-width: 0;
-
-  &--data {
-    width: 340px;
-    flex-shrink: 0;
-    background: rgb(var(--bg-card-rgb));
-    border-right: 1px solid rgb(var(--border-rgb));
-  }
-
-  &--editor {
-    flex: 1;
-    background: rgb(var(--bg-app-rgb));
-    padding: 20px;
-  }
-}
-
-// ═══ LEFT PANEL ═════════════════════════════════════════════
-.col-head {
-  display: flex; align-items: center; gap: 8px;
-  padding: 13px 16px;
-  font-size: .68rem; font-weight: 700;
-  text-transform: uppercase; letter-spacing: .1em;
-  color: rgb(var(--fg-rgb) / .55);
-  border-bottom: 1px solid rgb(var(--border-rgb));
-  flex-shrink: 0;
-  background: rgb(var(--bg-card-rgb));
-  svg { color: rgb(var(--accent-rgb)); }
-}
-
-.panel-scroll {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  padding: 14px;
-  display: flex; flex-direction: column; gap: 10px;
-
-  &::-webkit-scrollbar { width: 4px; }
-  &::-webkit-scrollbar-thumb { background: rgb(var(--border-rgb)); border-radius: 2px; }
-}
-
-.data-meta {
-  background: rgb(var(--accent-rgb) / .06);
-  border: 1px solid rgb(var(--accent-rgb) / .14);
-  border-radius: 10px;
-  padding: 12px 14px;
-  display: flex; flex-direction: column; gap: 8px;
-
-  &__row { display: flex; justify-content: space-between; align-items: flex-start; gap: 10px; }
-  &__lbl {
-    font-size: .62rem; color: rgb(var(--fg-rgb) / .55);
-    text-transform: uppercase; letter-spacing: .08em;
-    white-space: nowrap; flex-shrink: 0; padding-top: 1px;
-    font-weight: 600;
-  }
-  &__val {
-    font-size: .8rem; color: rgb(var(--fg-strong-rgb));
-    font-family: t.$font-mono; text-align: right; word-break: break-all;
-  }
-}
-
-.data-section-lbl {
-  font-size: .6rem; text-transform: uppercase; letter-spacing: .12em;
-  color: rgb(var(--fg-rgb) / .4); padding: 6px 2px 2px;
-  font-family: t.$font-mono; font-weight: 700;
-  display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap;
-}
-.data-section-hint {
-  text-transform: none; letter-spacing: 0;
-  font-family: t.$font-body; font-weight: 500;
-  font-size: .68rem; color: rgb(var(--accent-rgb));
-}
-.data-empty {
-  padding: 14px 12px; border-radius: 9px;
-  border: 1px dashed rgb(var(--border-rgb));
-  background: rgb(var(--bg-app-rgb) / .5);
-  font-size: .78rem; color: rgb(var(--fg-rgb) / .55);
-  text-align: center;
-}
-
-.data-item {
-  background: rgb(var(--bg-app-rgb));
-  border: 1px solid rgb(var(--border-rgb));
-  border-radius: 9px; padding: 11px 13px;
-  display: flex; flex-direction: column; gap: 6px;
-  transition: border-color .15s, background .15s;
-  &:hover { border-color: rgb(var(--accent-rgb) / .3); }
-}
-
-.data-label {
-  font-size: .6rem; text-transform: uppercase; letter-spacing: .09em;
-  color: rgb(var(--fg-rgb) / .55); font-family: t.$font-mono;
-  font-weight: 600;
-}
-
-.data-value {
-  font-size: .85rem; color: rgb(var(--fg-strong-rgb));
-  word-break: break-word; line-height: 1.5;
-}
-
-.data-file {
-  display: flex; align-items: center; gap: 8px;
-  padding: 4px 0;
-  flex-wrap: wrap;
-  &__name {
-    flex: 1 1 100%;
-    min-width: 0;
-    font-size: .78rem; color: rgb(var(--fg-rgb) / .8);
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  }
-  &__btn {
-    padding: 4px 10px; border-radius: 6px; font-size: .72rem; font-weight: 600;
-    background: rgb(var(--accent-rgb) / .12);
-    border: 1px solid rgb(var(--accent-rgb) / .25);
-    color: rgb(var(--accent-rgb)); cursor: pointer; transition: all .15s;
-    white-space: nowrap; flex-shrink: 0;
-    &:hover { background: rgb(var(--accent-rgb) / .22); }
-  }
-}
-
-.data-files { display: flex; flex-direction: column; gap: 2px; }
-
-// ── OCR badge ───────────────────────────────────────────────
-.ocr-badge {
-  font-size: .65rem;
-  font-weight: 700;
-  letter-spacing: .03em;
-  text-transform: uppercase;
-  padding: 2px 7px;
-  border-radius: 999px;
-  flex-shrink: 0;
-  white-space: nowrap;
-
-  &--pending {
-    background: rgb(var(--fg-rgb) / .08);
-    color:      rgb(var(--fg-rgb) / .55);
-    border: 1px solid rgb(var(--fg-rgb) / .12);
-  }
-  &--done {
-    background: rgba(16, 185, 129, .12);
-    color:      rgb(5, 122, 85);
-    border: 1px solid rgba(16, 185, 129, .35);
-  }
-  &--failed {
-    background: rgba(239, 68, 68, .12);
-    color:      rgb(185, 28, 28);
-    border: 1px solid rgba(239, 68, 68, .35);
-  }
-}
-
-.data-file__btn--ocr {
-  background: rgba(16, 185, 129, .14) !important;
-  border-color: rgba(16, 185, 129, .35) !important;
-  color: rgb(5, 122, 85) !important;
-  &:hover { background: rgba(16, 185, 129, .24) !important; }
-}
-
-.data-file__btn--retry {
-  background: rgba(239, 68, 68, .12) !important;
-  border-color: rgba(239, 68, 68, .35) !important;
-  color: rgb(185, 28, 28) !important;
-  &:hover { background: rgba(239, 68, 68, .22) !important; }
-}
-
-// ── OCR text viewer modal ───────────────────────────────────
-.ws-ocr-modal {
-  max-width: 720px;
-  width: 90vw;
-  max-height: 85vh;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.ws-ocr-meta {
-  display: flex;
-  flex-wrap: wrap;
+// ═══ COCKPIT GRID ═══════════════════════════════════════════
+.ws-cockpit {
+  display: grid;
+  grid-template-columns: minmax(0, 320px) 1fr minmax(0, 320px);
   gap: 14px;
-  padding: 8px 16px;
-  font-size: .75rem;
-  color: rgb(var(--fg-rgb) / .75);
-  border-bottom: 1px solid rgb(var(--fg-rgb) / .08);
-  flex-shrink: 0;
-  strong { color: rgb(var(--fg-rgb) / .9); margin-right: 4px; }
-}
-
-.ws-ocr-body {
-  padding: 12px 16px 16px;
-  flex: 1 1 auto;
+  padding: 14px 18px 20px;
+  flex: 1;
   min-height: 0;
-  overflow-y: auto !important;
-  overflow-x: hidden;
-  display: block;          // override base flex center
-  align-items: stretch;
-  justify-content: flex-start;
-  background: rgb(var(--bg-card-rgb));
-}
+  overflow: hidden;
+  transition: grid-template-columns .25s ease;
 
-.ws-ocr-text {
-  margin: 0;
-  font-family: ui-monospace, "Cascadia Code", Consolas, Menlo, monospace;
-  font-size: .78rem;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
-  color: rgb(var(--fg-rgb) / .88);
-}
-
-.ws-ocr-empty { font-size: .8rem; color: rgb(var(--fg-rgb) / .55); }
-
-.ws-ocr-error {
-  background: rgba(239, 68, 68, .08);
-  border: 1px solid rgba(239, 68, 68, .35);
-  color: rgb(185, 28, 28);
-  padding: 8px 12px;
-  border-radius: 8px;
-  font-size: .78rem;
-  margin-bottom: 10px;
-}
-
-// ── AI Suggestions card ─────────────────────────────────────
-.ai-suggest {
-  margin-top: 2px;
-  background: linear-gradient(135deg,
-    rgb(var(--accent-rgb) / .08),
-    rgb(var(--accent-rgb) / .03));
-  border: 1px solid rgb(var(--accent-rgb) / .25);
-  border-radius: 11px;
-  padding: 12px 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-
-  &__head {
-    display: flex; align-items: center; gap: 7px;
-    font-family: t.$font-mono;
-    font-size: .64rem;
-    font-weight: 700;
-    letter-spacing: .08em;
-    text-transform: uppercase;
-    color: rgb(var(--accent-rgb));
-    svg { flex-shrink: 0; }
-  }
-
-  &__list {
-    margin: 0; padding: 0 0 0 16px;
-    display: flex; flex-direction: column; gap: 5px;
-    li {
-      font-size: .8rem;
-      line-height: 1.5;
-      color: rgb(var(--fg-strong-rgb));
-      &::marker { color: rgb(var(--accent-rgb)); }
+  // État replié : rail masqué
+  &--rail-collapsed {
+    grid-template-columns: 0 1fr minmax(0, 320px);
+    .ws-rail {
+      opacity: 0;
+      pointer-events: none;
+      padding: 0;
+      margin: 0;
+      overflow: hidden;
+      max-height: 0;
     }
   }
+
+  // Responsive : réduction des colonnes
+  @media (max-width: 1200px) {
+    grid-template-columns: minmax(0, 260px) 1fr minmax(0, 260px);
+    &--rail-collapsed {
+      grid-template-columns: 0 1fr minmax(0, 260px);
+    }
+  }
+  @media (max-width: 980px) {
+    grid-template-columns: 1fr;
+    overflow-y: auto;
+    .ws-rail, .ws-deck { display: none; }
+    .ws-center { padding-right: 0; }
+    // Le bouton flottant reste visible dans le centre
+  }
+  @media (max-width: 560px) {
+    padding: 10px;
+    gap: 8px;
+  }
 }
 
-// ── Quick-insert chips above textarea ───────────────────────
-.editor-chips {
+// ── LEFT: vertical step rail ─────────────────────────────
+.ws-rail {
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  padding: 10px 18px 0;
-  flex-shrink: 0;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  padding-right: 4px;
+  transition: opacity .2s ease, padding .2s ease;
+}
+.rail-head {
+  display: flex;
+  align-items: baseline; justify-content: space-between;
+  padding: 0 4px 6px;
+  &__title { font: 700 .85rem t.$font-display; color: rgb(var(--fg-strong-rgb)); }
+  &__count { font: 600 .7rem t.$font-mono; color: rgb(var(--fg-rgb) / .5); }
+}
+.rail-meta {
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 10px 12px; border-radius: 10px;
+  background: rgb(var(--bg-card-rgb) / .55);
+  border: 1px solid rgb(var(--accent-rgb) / .12);
+  &__row { display: flex; justify-content: space-between; gap: 8px; font-size: .76rem; }
+  &__lbl { color: rgb(var(--fg-rgb) / .5); text-transform: uppercase; letter-spacing: .04em; font-family: t.$font-mono; font-size: .65rem; }
+  &__val { color: rgb(var(--fg-strong-rgb)); font-weight: 600; text-align: right; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 60%; }
+}
+.rail-list {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.rail-item {
+  display: flex; gap: 10px; align-items: center;
+  padding: 9px 10px; border-radius: 9px; cursor: pointer;
+  border: 1px solid transparent;
+  transition: background .15s, border-color .15s;
+  &:hover { background: rgb(var(--accent-rgb) / .06); }
+  &__num {
+    flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    background: rgb(var(--fg-rgb) / .08); border: 1px solid rgb(var(--fg-rgb) / .12);
+    font: 700 .68rem t.$font-mono; color: rgb(var(--fg-rgb) / .55);
+  }
+  &__body { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
+  &__name { font: 600 .8rem t.$font-body; color: rgb(var(--fg-strong-rgb)); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  &__sub { font: 600 .68rem t.$font-mono; color: rgb(var(--fg-rgb) / .5); display: inline-flex; gap: 6px; align-items: center; }
+  &__dot { color: rgb(var(--warning-rgb)); font-weight: 700; }
+
+  &--active {
+    background: color-mix(in srgb, var(--color-btn-add, #059669) 8%, transparent);
+    border-color: color-mix(in srgb, var(--color-btn-add, #059669) 35%, transparent);
+    .rail-item__num { background: var(--color-btn-add, #059669); border-color: var(--color-btn-add, #059669); color: #fff; }
+  }
+  &--rollup-compliant .rail-item__num { background: rgb(var(--success-rgb) / .15); border-color: rgb(var(--success-rgb) / .45); color: rgb(var(--success-rgb)); }
+  &--rollup-partial   .rail-item__num { background: rgb(var(--warning-rgb) / .15); border-color: rgb(var(--warning-rgb) / .45); color: rgb(var(--warning-rgb)); }
+  &--rollup-nc        .rail-item__num { background: rgb(var(--danger-rgb) / .15); border-color: rgb(var(--danger-rgb) / .45); color: rgb(var(--danger-rgb)); }
+  &--rollup-compliant .rail-item__sub { color: rgb(var(--success-rgb)); }
+  &--rollup-partial   .rail-item__sub { color: rgb(var(--warning-rgb)); }
+  &--rollup-nc        .rail-item__sub { color: rgb(var(--danger-rgb)); }
 }
 
-.chip {
-  padding: 5px 11px;
-  border-radius: 100px;
-  font-family: t.$font-body;
-  font-size: .73rem;
-  font-weight: 600;
-  cursor: pointer;
-  border: 1px solid;
-  transition: all .15s;
-  background: rgb(var(--fg-rgb) / .04);
-  border-color: rgb(var(--border-rgb));
-  color: rgb(var(--fg-rgb) / .7);
-
-  &:hover { transform: translateY(-1px); }
-
-  &--ok {
-    background: rgb(var(--success-rgb) / .1);
-    border-color: rgb(var(--success-rgb) / .25);
-    color: rgb(var(--success-rgb));
-    &:hover { background: rgb(var(--success-rgb) / .18); }
-  }
-  &--warn {
-    background: rgb(var(--warning-rgb) / .1);
-    border-color: rgb(var(--warning-rgb) / .25);
-    color: rgb(var(--warning-rgb));
-    &:hover { background: rgb(var(--warning-rgb) / .18); }
-  }
-  &--info {
-    background: rgb(var(--accent-rgb) / .08);
-    border-color: rgb(var(--accent-rgb) / .2);
-    color: rgb(var(--accent-rgb));
-    &:hover { background: rgb(var(--accent-rgb) / .16); }
-  }
-  &--accent {
-    background: rgb(var(--accent-rgb) / .14);
-    border-color: rgb(var(--accent-rgb) / .3);
-    color: rgb(var(--accent-strong-rgb));
-    &:hover { background: rgb(var(--accent-rgb) / .24); }
-  }
-}
-
-// ═══ CENTER: EDITOR CARD ═════════════════════════════════════
-.editor-card {
+// ── CENTER: per-question cards (scrollable questions + fixed deck) ──
+.ws-center {
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  gap: 0;
+  padding-right: 6px;
+  position: relative;
+}
+
+// Bouton flottant toujours visible en haut à gauche du centre
+.ws-rail-toggle--floating {
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 10;
+  margin: 4px 0 4px -8px;
   background: rgb(var(--bg-card-rgb));
   border: 1px solid rgb(var(--border-rgb));
-  border-radius: 14px;
-  overflow: hidden;
-  box-shadow: 0 1px 2px rgb(var(--fg-strong-rgb) / .04);
+  border-radius: 6px;
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgb(var(--fg-rgb) / .55);
+  cursor: pointer;
+  transition: all .15s;
+  flex-shrink: 0;
 
-  &__head {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    padding: 14px 18px;
-    border-bottom: 1px solid rgb(var(--border-rgb));
-    flex-shrink: 0;
+  &:hover {
+    background: rgb(var(--fg-rgb) / .06);
+    color: rgb(var(--fg-strong-rgb));
+    border-color: rgb(var(--accent-rgb) / .3);
+  }
+
+  // Sur petit écran, le bouton reste mais le rail est masqué
+  @media (max-width: 980px) {
+    position: relative;
+    margin: 0 0 4px 0;
   }
 }
 
-.ech-left {
-  display: flex; align-items: center; gap: 8px; min-width: 0;
-  svg { color: rgb(var(--accent-rgb)); flex-shrink: 0; }
-}
-.ech-label {
-  font-size: .72rem; font-weight: 700; text-transform: uppercase;
-  letter-spacing: .1em; color: rgb(var(--fg-rgb) / .55);
-}
-.ech-step {
-  font-family: t.$font-display;
-  font-size: .95rem; font-weight: 700;
-  color: rgb(var(--fg-strong-rgb));
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.ech-right { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
-
-.col-badge {
-  padding: 3px 10px; border-radius: 100px;
-  font-size: .65rem; font-weight: 700;
-  letter-spacing: .04em; text-transform: uppercase;
-  font-family: t.$font-mono;
-  &--saved { background: rgb(var(--success-rgb) / .12); border: 1px solid rgb(var(--success-rgb) / .25); color: rgb(var(--success-rgb)); }
-  &--draft { background: rgb(var(--warning-rgb) / .12); border: 1px solid rgb(var(--warning-rgb) / .25); color: rgb(var(--warning-rgb)); }
-  &--empty { background: rgb(var(--fg-rgb) / .05); border: 1px solid rgb(var(--border-rgb)); color: rgb(var(--fg-rgb) / .5); }
-}
-
-.ws-textarea {
-  flex: 1;
+// ── Scrollable question area ──
+.qcards-scroll {
+  flex: 3 1 0;
+  overflow-y: auto;
   min-height: 0;
-  width: 100%;
-  padding: 22px 26px;
-  background: transparent; border: none; outline: none; resize: none;
-  font-family: t.$font-body; font-size: .95rem; line-height: 1.8;
-  color: rgb(var(--fg-strong-rgb));
-  &::placeholder { color: rgb(var(--fg-rgb) / .35); line-height: 2; }
-  &:disabled { opacity: .55; cursor: not-allowed; }
+  padding-right: 4px;
+  padding-bottom: 8px;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: rgb(var(--border-rgb));
+    border-radius: 2px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
 }
 
-.editor-footer {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 12px 18px;
-  padding-right: 96px; // leave clear space for floating chat FAB
-  border-top: 1px solid rgb(var(--border-rgb));
-  flex-shrink: 0;
+.qcards {
+  display: flex;
+  flex-direction: column;
   gap: 10px;
-  background: rgb(var(--bg-app-rgb) / .4);
 }
 
-.ef-left { display: flex; gap: 8px; align-items: center; }
-
-.ef-status {
-  font-size: .72rem; font-family: t.$font-mono; font-weight: 600;
-  padding: 4px 10px; border-radius: 100px;
-  &--saved { background: rgb(var(--success-rgb) / .12); border: 1px solid rgb(var(--success-rgb) / .25); color: rgb(var(--success-rgb)); }
-  &--draft { background: rgb(var(--warning-rgb) / .12); border: 1px solid rgb(var(--warning-rgb) / .25); color: rgb(var(--warning-rgb)); }
+// ── Fixed Findings & Recommendations ──
+.ws-deck-bottom {
+  flex: 7 1 0;
+  overflow-y: auto;
+  min-height: 0;
+  padding-top: 16px;
+  border-top: 1px solid rgb(var(--border-rgb));
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 0;
 }
 
-.ef-del {
-  display: flex; align-items: center; gap: 5px;
-  padding: 5px 11px; border-radius: 7px;
-  background: rgb(var(--danger-rgb) / .08);
-  border: 1px solid rgb(var(--danger-rgb) / .2);
-  color: rgb(var(--danger-rgb)); font-size: .75rem; font-weight: 600;
-  cursor: pointer; transition: all .15s;
-  &:hover { background: rgb(var(--danger-rgb) / .18); }
+// ── RIGHT: auditor deck (Step note only) ─────────────────
+.ws-deck {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+.deck-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgb(var(--bg-card-rgb) / .7);
+  border: 1px solid rgb(var(--accent-rgb) / .14);
+  &__head { display: flex; align-items: center; justify-content: space-between; }
+  &__title { font: 700 .8rem t.$font-display; color: rgb(var(--fg-strong-rgb)); letter-spacing: .01em; }
+  &__add {
+    background: transparent; border: 1px solid rgb(var(--accent-rgb) / .3);
+    color: var(--color-btn-add, #059669);
+    padding: 3px 10px; border-radius: 6px; cursor: pointer;
+    font: 600 .72rem t.$font-mono;
+    &:hover:not(:disabled) { background: var(--color-btn-add, #059669); color: #fff; border-color: var(--color-btn-add, #059669); }
+    &:disabled { opacity: .4; cursor: not-allowed; }
+  }
+  &__sub { font: 600 .65rem t.$font-mono; color: rgb(var(--fg-rgb) / .5); }
+}
+.deck-empty {
+  font-size: .76rem; color: rgb(var(--fg-rgb) / .45);
+  padding: 8px 4px; font-style: italic;
+}
+.finding, .rec {
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 8px;
+  border-radius: 8px;
+  background: rgb(var(--bg-app-rgb) / .5);
+  border: 1px solid rgb(var(--accent-rgb) / .1);
+}
+.finding__head { display: flex; align-items: center; gap: 8px; }
+.finding__sev {
+  background: rgb(var(--bg-card-rgb)); border: 1px solid rgb(var(--accent-rgb) / .2);
+  color: rgb(var(--fg-strong-rgb)); border-radius: 5px;
+  padding: 3px 6px; font: 600 .7rem t.$font-mono; cursor: pointer;
+}
+.finding__sev-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  &--low      { background: rgb(var(--success-rgb)); }
+  &--medium   { background: rgb(var(--warning-rgb)); }
+  &--high     { background: #ea580c; }
+  &--critical { background: rgb(var(--danger-rgb)); }
+}
+.finding__del, .rec__del {
+  margin-left: auto;
+  background: transparent; border: none; cursor: pointer;
+  color: rgb(var(--fg-rgb) / .4); font-size: 1.2rem; line-height: 1;
+  padding: 2px 6px; border-radius: 4px;
+  &:hover:not(:disabled) { color: rgb(var(--danger-rgb)); background: rgb(var(--danger-rgb) / .1); }
+  &:disabled { opacity: .3; cursor: not-allowed; }
 }
 
-.ef-nav { display: flex; gap: 8px; }
+// ── Combinaison pour les champs texte (findings, recs, notes) ──
+.finding__text, .rec__text, .deck-note {
+  width: 100%;
+  resize: vertical;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgb(var(--bg-card-rgb));
+  border: 1px solid rgb(var(--accent-rgb) / .15);
+  color: rgb(var(--fg-strong-rgb));
+  font: 400 .82rem t.$font-body;
+  line-height: 1.5;
+  min-height: 60px;        // hauteur minimale pour les findings
+  height: auto;            // s'adapte au contenu
+  overflow-y: auto;        // barre de défilement si nécessaire
 
+  &:focus {
+    outline: none;
+    border-color: var(--color-btn-add, #059669);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-btn-add, #059669) 14%, transparent);
+  }
+}
+
+// Pour les recommandations, on peut garder une hauteur min un peu plus petite
+.rec__text {
+  min-height: 60px;
+}
+
+// Pour les notes, une hauteur un peu plus grande
+.deck-note {
+  min-height: 80px;
+}
+
+// Les anciennes règles sont remplacées par celles-ci, on supprime l'ancien bloc séparé.
+
+.rec {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 4px;
+}
+.rec__text { flex: 1; }
+
+// ── Center head, AI suggestions, verdicts ──
+.center-head {
+  flex-shrink: 0;
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgb(var(--bg-card-rgb) / .7);
+  border: 1px solid rgb(var(--accent-rgb) / .14);
+  &__top { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  &__pill { font: 600 .65rem t.$font-mono; letter-spacing: .08em; color: rgb(var(--fg-rgb) / .55); text-transform: uppercase; }
+  &__progress { margin-left: auto; font: 600 .72rem t.$font-mono; color: rgb(var(--fg-rgb) / .55); }
+  &__title { margin: 0; font: 700 1.05rem t.$font-display; color: rgb(var(--fg-strong-rgb)); line-height: 1.3; }
+}
+.rollup-badge {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 10px; border-radius: 999px;
+  font: 700 .68rem t.$font-mono; letter-spacing: .04em; text-transform: uppercase;
+  &--compliant { color: rgb(var(--success-rgb)); background: rgb(var(--success-rgb) / .12); border: 1px solid rgb(var(--success-rgb) / .35); }
+  &--partial   { color: rgb(var(--warning-rgb)); background: rgb(var(--warning-rgb) / .12); border: 1px solid rgb(var(--warning-rgb) / .35); }
+  &--nc        { color: rgb(var(--danger-rgb)); background: rgb(var(--danger-rgb) / .12); border: 1px solid rgb(var(--danger-rgb) / .35); }
+  &--pending   { color: rgb(var(--fg-rgb) / .55); background: rgb(var(--fg-rgb) / .06); border: 1px solid rgb(var(--fg-rgb) / .12); }
+}
+.ai-suggest-box {
+  border: 1px solid rgb(var(--accent-rgb) / .18); border-radius: 10px;
+  background: rgb(var(--accent-rgb) / .04);
+  summary {
+    cursor: pointer; padding: 9px 14px; list-style: none;
+    display: flex; align-items: center; gap: 8px;
+    font: 700 .72rem t.$font-mono; letter-spacing: .04em;
+    color: var(--color-btn-add, #059669); text-transform: uppercase;
+    &::-webkit-details-marker { display: none; }
+  }
+  .ai-suggest-loading {
+    font-weight: 600; text-transform: none; letter-spacing: 0;
+    color: rgb(var(--fg-rgb) / .4);
+  }
+  ul { margin: 0; padding: 4px 16px 14px 32px; list-style: disc;
+    color: rgb(var(--fg-rgb) / .8); font-size: .82rem; line-height: 1.5;
+    li + li { margin-top: 4px; } }
+}
+
+.qcard-empty {
+  padding: 32px; text-align: center; border-radius: 12px;
+  background: rgb(var(--bg-card-rgb) / .4);
+  border: 1px dashed rgb(var(--accent-rgb) / .2);
+  color: rgb(var(--fg-rgb) / .45); font-size: .82rem;
+}
+.qcard {
+  padding: 14px 16px; border-radius: 12px;
+  background: rgb(var(--bg-card-rgb) / .85);
+  border: 1px solid rgb(var(--accent-rgb) / .14);
+  border-left: 3px solid rgb(var(--fg-rgb) / .15);
+  display: flex; flex-direction: column; gap: 10px;
+  transition: border-color .2s;
+
+  &--compliant   { border-left-color: rgb(var(--success-rgb)); }
+  &--observation { border-left-color: rgb(var(--warning-rgb)); }
+  &--nc          { border-left-color: rgb(var(--danger-rgb)); }
+  &--na          { border-left-color: rgb(var(--fg-rgb) / .25); opacity: .85; }
+
+  // ── Collapsible body ──
+  &--collapsed &__body {
+    display: none;
+  }
+  &--collapsed &__toggle .fa-chevron-down {
+    transform: rotate(-90deg);
+  }
+
+  &__head { display: flex; gap: 10px; align-items: baseline; flex-wrap: wrap; }
+  &__idx { font: 700 .7rem t.$font-mono; color: var(--color-btn-add, #059669); background: rgb(16 130 96 / .1); padding: 2px 8px; border-radius: 4px; flex-shrink: 0; }
+  &__label { font: 600 .92rem t.$font-body; color: rgb(var(--fg-strong-rgb)); line-height: 1.4; flex: 1; }
+
+  &__toggle {
+    background: transparent; border: 1px solid rgb(var(--border-rgb));
+    border-radius: 6px; padding: 2px 8px; cursor: pointer;
+    color: rgb(var(--fg-rgb) / .55); font-size: .75rem;
+    transition: all .15s; white-space: nowrap;
+    &:hover { background: rgb(var(--fg-rgb) / .06); color: rgb(var(--fg-strong-rgb));
+              border-color: rgb(var(--accent-rgb) / .3); }
+    i { transition: transform .2s ease; }
+  }
+
+  &__body { display: flex; flex-direction: column; gap: 10px; }
+
+  &__answer { display: flex; flex-direction: column; gap: 3px; padding: 8px 12px; border-radius: 8px; background: rgb(var(--bg-app-rgb) / .5); }
+  &__answer-lbl { font: 600 .62rem t.$font-mono; letter-spacing: .06em; text-transform: uppercase; color: rgb(var(--fg-rgb) / .45); }
+  &__answer-val { font: 500 .85rem t.$font-body; color: rgb(var(--fg-strong-rgb)); white-space: pre-wrap; word-break: break-word; }
+  &__evidence { display: flex; flex-wrap: wrap; gap: 6px; }
+}
+.evidence-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 8px; border-radius: 6px;
+  background: rgb(var(--accent-rgb) / .07);
+  border: 1px solid rgb(var(--accent-rgb) / .2);
+  font-size: .72rem; color: rgb(var(--fg-strong-rgb));
+  max-width: 100%; min-width: 0;
+  svg { color: var(--color-btn-add, #059669); flex-shrink: 0; }
+  &__name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 180px; }
+  &__btn {
+    background: rgb(var(--bg-app-rgb) / .8); border: 1px solid rgb(var(--accent-rgb) / .2);
+    color: var(--color-btn-add, #059669);
+    padding: 1px 7px; border-radius: 4px; cursor: pointer;
+    font: 600 .68rem t.$font-mono;
+    &:hover { background: var(--color-btn-add, #059669); color: #fff; }
+    &--retry { color: rgb(var(--warning-rgb)); border-color: rgb(var(--warning-rgb) / .3); }
+  }
+}
+.verdict-row {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+  &__lbl { font: 600 .65rem t.$font-mono; letter-spacing: .06em; text-transform: uppercase; color: rgb(var(--fg-rgb) / .5); margin-right: 4px; }
+  &--readonly .vchip { opacity: .9; cursor: default; }
+}
+.vchip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 4px 10px; border-radius: 999px;
+  font: 600 .72rem t.$font-mono;
+  border: 1px solid transparent;
+  background: rgb(var(--fg-rgb) / .05);
+  color: rgb(var(--fg-rgb) / .55);
+  cursor: pointer; transition: all .12s;
+  &:hover { background: rgb(var(--fg-rgb) / .1); }
+  &--compliant.vchip--on   { background: rgb(var(--success-rgb)); color: #fff; border-color: rgb(var(--success-rgb)); }
+  &--observation.vchip--on { background: rgb(var(--warning-rgb)); color: #fff; border-color: rgb(var(--warning-rgb)); }
+  &--nc.vchip--on          { background: rgb(var(--danger-rgb)); color: #fff; border-color: rgb(var(--danger-rgb)); }
+  &--na.vchip--on          { background: rgb(var(--fg-rgb) / .25); color: #fff; border-color: rgb(var(--fg-rgb) / .25); }
+}
+.center-nav {
+  display: flex; justify-content: space-between; gap: 10px;
+  padding-top: 10px;
+}
 .ef-btn {
   padding: 7px 16px; border-radius: 8px;
   font-family: t.$font-body; font-size: .82rem; font-weight: 600;
@@ -633,19 +640,46 @@
   background: rgb(var(--bg-card-rgb));
   border: 1px solid rgb(var(--border-rgb));
   color: rgb(var(--fg-strong-rgb));
-  &:hover:not(:disabled) {
-    background: rgb(var(--fg-rgb) / .06);
-    border-color: rgb(var(--accent-rgb) / .4);
-  }
+  &:hover:not(:disabled) { background: rgb(var(--fg-rgb) / .06); border-color: rgb(var(--accent-rgb) / .4); }
   &:disabled { opacity: .4; cursor: not-allowed; }
   &--next {
     background: linear-gradient(135deg, rgb(var(--accent-rgb)), rgb(var(--accent-strong-rgb)));
     border-color: rgb(var(--accent-strong-rgb));
     color: #fff;
     box-shadow: 0 4px 10px rgb(var(--accent-rgb) / .3);
-    &:hover:not(:disabled) {
-      transform: translateY(-1px);
-      box-shadow: 0 6px 14px rgb(var(--accent-rgb) / .42);
+    &:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 6px 14px rgb(var(--accent-rgb) / .42); }
+  }
+  &--complete {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: linear-gradient(135deg, rgb(var(--success-rgb)), rgb(var(--success-rgb) / .82));
+    border-color: rgb(var(--success-rgb));
+    color: #fff;
+    box-shadow: 0 4px 10px rgb(var(--success-rgb) / .3);
+    &:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 6px 14px rgb(var(--success-rgb) / .42); }
+  }
+}
+
+// ── Collapse/Expand toolbar ──
+.qcards-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+
+  .collapse-toggle {
+    background: transparent;
+    border: 1px solid rgb(var(--border-rgb));
+    border-radius: 6px;
+    padding: 4px 12px;
+    color: rgb(var(--fg-rgb) / .55);
+    cursor: pointer;
+    font-size: .75rem;
+    font-weight: 500;
+    transition: all .15s;
+
+    &:hover {
+      background: rgb(var(--fg-rgb) / .06);
+      color: rgb(var(--fg-strong-rgb));
+      border-color: rgb(var(--accent-rgb) / .3);
     }
   }
   &--complete {
@@ -684,9 +718,8 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 14px;
-  pointer-events: none;          // children re-enable
+  pointer-events: none;
 }
-
 .ws-chat__panel {
   pointer-events: auto;
   width: 380px;
@@ -696,14 +729,11 @@
   background: rgb(var(--bg-card-rgb));
   border: 1px solid rgb(var(--border-rgb));
   border-radius: 18px;
-  box-shadow:
-    0 24px 60px rgb(var(--fg-strong-rgb) / .18),
-    0 6px 16px rgb(var(--fg-strong-rgb) / .08);
+  box-shadow: 0 24px 60px rgb(var(--fg-strong-rgb) / .18), 0 6px 16px rgb(var(--fg-strong-rgb) / .08);
   overflow: hidden;
   display: flex;
   flex-direction: column;
   animation: chatPop .22s cubic-bezier(.34,1.56,.64,1) both;
-
   app-audit-bot {
     flex: 1;
     min-height: 0;
@@ -712,7 +742,6 @@
     overflow: hidden;
   }
 }
-
 .ws-chat__fab {
   pointer-events: auto;
   width: 56px; height: 56px;
@@ -722,12 +751,9 @@
   color: #fff;
   display: flex; align-items: center; justify-content: center;
   cursor: pointer;
-  box-shadow:
-    0 12px 28px rgb(var(--accent-rgb) / .45),
-    0 4px 10px rgb(var(--accent-rgb) / .25);
+  box-shadow: 0 12px 28px rgb(var(--accent-rgb) / .45), 0 4px 10px rgb(var(--accent-rgb) / .25);
   transition: transform .2s ease, box-shadow .2s ease;
   position: relative;
-
   &::after {
     content: '';
     position: absolute;
@@ -738,14 +764,10 @@
     animation: fabPulse 2s ease-in-out infinite;
     pointer-events: none;
   }
-
   &:hover {
     transform: translateY(-2px) scale(1.04);
-    box-shadow:
-      0 16px 36px rgb(var(--accent-rgb) / .55),
-      0 6px 14px rgb(var(--accent-rgb) / .3);
+    box-shadow: 0 16px 36px rgb(var(--accent-rgb) / .55), 0 6px 14px rgb(var(--accent-rgb) / .3);
   }
-
   &--open {
     background: rgb(var(--bg-card-rgb));
     color: rgb(var(--fg-strong-rgb));
@@ -755,12 +777,10 @@
     &:hover { box-shadow: 0 10px 24px rgb(var(--fg-strong-rgb) / .18); }
   }
 }
-
 @keyframes chatPop {
   from { opacity: 0; transform: translateY(12px) scale(.96); }
   to   { opacity: 1; transform: translateY(0)    scale(1); }
 }
-
 @keyframes fabPulse {
   0%   { opacity: .6; transform: scale(1); }
   70%  { opacity: 0;  transform: scale(1.4); }
@@ -816,43 +836,14 @@
 .file-preview-img    { max-width: 100%; max-height: 80vh; object-fit: contain; }
 .file-preview-iframe { width: 100%; height: 80vh; border: none; }
 
-// ═══ RESPONSIVE ═════════════════════════════════════════════
-@media (max-width: 1024px) {
-  .ws-col--data { width: 280px; }
-  .ws-chat__panel { width: 340px; height: 480px; }
-}
-
-@media (max-width: 768px) {
-  .ws-col--data {
-    width: 240px;
-  }
-  .ws-col--editor { padding: 12px; }
-  .ws-stepper { padding: 10px 14px; }
-  .ws-chat { right: 14px; bottom: 14px; }
-  .ws-chat__panel {
-    width: calc(100vw - 28px);
-    height: 70vh;
-  }
-}
-
-@media (max-width: 560px) {
-  .ws-col--data { display: none; }   // hidden on phones; reachable via future drawer
-}
-
-// ═══════════════════════════════════════════════════════════
-// PHASE 1+2 — 3-pane auditor cockpit
-// ═══════════════════════════════════════════════════════════
-
-// Live risk roll-up in the topbar
+// ═══ LIVE RISK ROLL-UP ══════════════════════════════════════
 .ws-roll {
   display: inline-flex; align-items: center; gap: 8px;
   padding: 4px 10px; border-radius: 999px;
   background: rgb(var(--bg-card-rgb) / .6);
   border: 1px solid rgb(var(--accent-rgb) / .18);
-  &__bar { width: 90px; height: 6px; border-radius: 3px;
-    background: rgb(var(--fg-rgb) / .08); overflow: hidden; }
-  &__fill { display: block; height: 100%;
-    background: var(--color-btn-add, #059669); transition: width .3s; }
+  &__bar { width: 90px; height: 6px; border-radius: 3px; background: rgb(var(--fg-rgb) / .08); overflow: hidden; }
+  &__fill { display: block; height: 100%; background: var(--color-btn-add, #059669); transition: width .3s; }
   &__txt { font: 600 .72rem t.$font-mono; color: var(--color-btn-add, #059669); }
   &__stat { font: 600 .72rem t.$font-mono; padding: 0 6px; border-radius: 4px;
     &--find { color: rgb(var(--warning-rgb)); background: rgb(var(--warning-rgb) / .12); }
@@ -860,289 +851,9 @@
   }
 }
 
-// Cockpit grid
-.ws-cockpit {
-  display: grid;
-  grid-template-columns: 320px minmax(0, 1fr) 320px;
-  gap: 14px;
-  padding: 14px 18px 20px;
-  flex: 1; min-height: 0; overflow: hidden;
-  @media (max-width: 1200px) { grid-template-columns: 280px 1fr 280px; }
-  @media (max-width: 980px)  { grid-template-columns: 1fr; overflow: auto; }
-}
+// ═══ OCR / EVIDENCE DRAWER ══════════════════════════════════
+// Full styles for evidence drawer, OCR text viewer, clause picker, AI suggestion actions
 
-// ── LEFT: vertical step rail ─────────────────────────────
-.ws-rail {
-  display: flex; flex-direction: column; gap: 12px;
-  overflow-y: auto; padding-right: 4px;
-}
-.rail-head {
-  display: flex; align-items: baseline; justify-content: space-between;
-  padding: 0 4px 6px;
-  &__title { font: 700 .85rem t.$font-display; color: rgb(var(--fg-strong-rgb)); }
-  &__count { font: 600 .7rem t.$font-mono; color: rgb(var(--fg-rgb) / .5); }
-}
-.rail-meta {
-  display: flex; flex-direction: column; gap: 6px;
-  padding: 10px 12px; border-radius: 10px;
-  background: rgb(var(--bg-card-rgb) / .55);
-  border: 1px solid rgb(var(--accent-rgb) / .12);
-  &__row { display: flex; justify-content: space-between; gap: 8px; font-size: .76rem; }
-  &__lbl { color: rgb(var(--fg-rgb) / .5); text-transform: uppercase;
-    letter-spacing: .04em; font-family: t.$font-mono; font-size: .65rem; }
-  &__val { color: rgb(var(--fg-strong-rgb)); font-weight: 600; text-align: right;
-    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 60%; }
-}
-.rail-list {
-  list-style: none; padding: 0; margin: 0;
-  display: flex; flex-direction: column; gap: 4px;
-}
-.rail-item {
-  display: flex; gap: 10px; align-items: center;
-  padding: 9px 10px; border-radius: 9px; cursor: pointer;
-  border: 1px solid transparent;
-  transition: background .15s, border-color .15s;
-  &:hover { background: rgb(var(--accent-rgb) / .06); }
-  &__num {
-    flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%;
-    display: flex; align-items: center; justify-content: center;
-    background: rgb(var(--fg-rgb) / .08); border: 1px solid rgb(var(--fg-rgb) / .12);
-    font: 700 .68rem t.$font-mono; color: rgb(var(--fg-rgb) / .55);
-  }
-  &__body { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
-  &__name { font: 600 .8rem t.$font-body; color: rgb(var(--fg-strong-rgb));
-    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  &__sub { font: 600 .68rem t.$font-mono; color: rgb(var(--fg-rgb) / .5);
-    display: inline-flex; gap: 6px; align-items: center; }
-  &__dot { color: rgb(var(--warning-rgb)); font-weight: 700; }
-
-  &--active {
-    background: color-mix(in srgb, var(--color-btn-add, #059669) 8%, transparent);
-    border-color: color-mix(in srgb, var(--color-btn-add, #059669) 35%, transparent);
-    .rail-item__num { background: var(--color-btn-add, #059669);
-      border-color: var(--color-btn-add, #059669); color: #fff; }
-  }
-  &--rollup-compliant .rail-item__num { background: rgb(var(--success-rgb) / .15);
-    border-color: rgb(var(--success-rgb) / .45); color: rgb(var(--success-rgb)); }
-  &--rollup-partial   .rail-item__num { background: rgb(var(--warning-rgb) / .15);
-    border-color: rgb(var(--warning-rgb) / .45); color: rgb(var(--warning-rgb)); }
-  &--rollup-nc        .rail-item__num { background: rgb(var(--danger-rgb) / .15);
-    border-color: rgb(var(--danger-rgb) / .45); color: rgb(var(--danger-rgb)); }
-  &--rollup-compliant .rail-item__sub { color: rgb(var(--success-rgb)); }
-  &--rollup-partial   .rail-item__sub { color: rgb(var(--warning-rgb)); }
-  &--rollup-nc        .rail-item__sub { color: rgb(var(--danger-rgb)); }
-}
-
-// ── CENTER: per-question cards ──────────────────────────
-.ws-center {
-  display: flex; flex-direction: column; gap: 12px;
-  overflow-y: auto; padding-right: 6px;
-}
-.center-head {
-  display: flex; flex-direction: column; gap: 6px;
-  padding: 12px 16px; border-radius: 12px;
-  background: rgb(var(--bg-card-rgb) / .7);
-  border: 1px solid rgb(var(--accent-rgb) / .14);
-  &__top { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
-  &__pill { font: 600 .65rem t.$font-mono; letter-spacing: .08em;
-    color: rgb(var(--fg-rgb) / .55); text-transform: uppercase; }
-  &__progress { margin-left: auto; font: 600 .72rem t.$font-mono;
-    color: rgb(var(--fg-rgb) / .55); }
-  &__title { margin: 0; font: 700 1.05rem t.$font-display;
-    color: rgb(var(--fg-strong-rgb)); line-height: 1.3; }
-}
-.rollup-badge {
-  display: inline-flex; align-items: center; gap: 5px;
-  padding: 3px 10px; border-radius: 999px;
-  font: 700 .68rem t.$font-mono; letter-spacing: .04em; text-transform: uppercase;
-  &--compliant { color: rgb(var(--success-rgb)); background: rgb(var(--success-rgb) / .12);
-                 border: 1px solid rgb(var(--success-rgb) / .35); }
-  &--partial   { color: rgb(var(--warning-rgb)); background: rgb(var(--warning-rgb) / .12);
-                 border: 1px solid rgb(var(--warning-rgb) / .35); }
-  &--nc        { color: rgb(var(--danger-rgb)); background: rgb(var(--danger-rgb) / .12);
-                 border: 1px solid rgb(var(--danger-rgb) / .35); }
-  &--pending   { color: rgb(var(--fg-rgb) / .55); background: rgb(var(--fg-rgb) / .06);
-                 border: 1px solid rgb(var(--fg-rgb) / .12); }
-}
-
-.ai-suggest-box {
-  border: 1px solid rgb(var(--accent-rgb) / .18); border-radius: 10px;
-  background: rgb(var(--accent-rgb) / .04);
-  summary {
-    cursor: pointer; padding: 9px 14px; list-style: none;
-    display: flex; align-items: center; gap: 8px;
-    font: 700 .72rem t.$font-mono; letter-spacing: .04em;
-    color: var(--color-btn-add, #059669); text-transform: uppercase;
-    &::-webkit-details-marker { display: none; }
-  }
-  .ai-suggest-loading {
-    font-weight: 600; text-transform: none; letter-spacing: 0;
-    color: rgb(var(--fg-rgb) / .4);
-  }
-  ul { margin: 0; padding: 4px 16px 14px 32px; list-style: disc;
-    color: rgb(var(--fg-rgb) / .8); font-size: .82rem; line-height: 1.5;
-    li + li { margin-top: 4px; } }
-}
-
-.qcards { display: flex; flex-direction: column; gap: 10px; }
-.qcard-empty {
-  padding: 32px; text-align: center; border-radius: 12px;
-  background: rgb(var(--bg-card-rgb) / .4);
-  border: 1px dashed rgb(var(--accent-rgb) / .2);
-  color: rgb(var(--fg-rgb) / .45); font-size: .82rem;
-}
-.qcard {
-  padding: 14px 16px; border-radius: 12px;
-  background: rgb(var(--bg-card-rgb) / .85);
-  border: 1px solid rgb(var(--accent-rgb) / .14);
-  border-left: 3px solid rgb(var(--fg-rgb) / .15);
-  display: flex; flex-direction: column; gap: 10px;
-  transition: border-color .2s;
-  &--compliant   { border-left-color: rgb(var(--success-rgb)); }
-  &--observation { border-left-color: rgb(var(--warning-rgb)); }
-  &--nc          { border-left-color: rgb(var(--danger-rgb)); }
-  &--na          { border-left-color: rgb(var(--fg-rgb) / .25); opacity: .85; }
-
-  &__head { display: flex; gap: 10px; align-items: baseline; }
-  &__idx { font: 700 .7rem t.$font-mono; color: var(--color-btn-add, #059669);
-           background: rgb(16 130 96 / .1); padding: 2px 8px; border-radius: 4px;
-           flex-shrink: 0; }
-  &__label { font: 600 .92rem t.$font-body; color: rgb(var(--fg-strong-rgb));
-             line-height: 1.4; }
-
-  &__answer { display: flex; flex-direction: column; gap: 3px;
-              padding: 8px 12px; border-radius: 8px;
-              background: rgb(var(--bg-app-rgb) / .5); }
-  &__answer-lbl { font: 600 .62rem t.$font-mono; letter-spacing: .06em;
-                  text-transform: uppercase; color: rgb(var(--fg-rgb) / .45); }
-  &__answer-val { font: 500 .85rem t.$font-body; color: rgb(var(--fg-strong-rgb));
-                  white-space: pre-wrap; word-break: break-word; }
-
-  &__evidence { display: flex; flex-wrap: wrap; gap: 6px; }
-}
-.evidence-chip {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 4px 8px; border-radius: 6px;
-  background: rgb(var(--accent-rgb) / .07);
-  border: 1px solid rgb(var(--accent-rgb) / .2);
-  font-size: .72rem; color: rgb(var(--fg-strong-rgb));
-  max-width: 100%; min-width: 0;
-  svg { color: var(--color-btn-add, #059669); flex-shrink: 0; }
-  &__name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-            max-width: 180px; }
-  &__btn {
-    background: rgb(var(--bg-app-rgb) / .8); border: 1px solid rgb(var(--accent-rgb) / .2);
-    color: var(--color-btn-add, #059669);
-    padding: 1px 7px; border-radius: 4px; cursor: pointer;
-    font: 600 .68rem t.$font-mono;
-    &:hover { background: var(--color-btn-add, #059669); color: #fff; }
-    &--retry { color: rgb(var(--warning-rgb)); border-color: rgb(var(--warning-rgb) / .3); }
-  }
-}
-
-.verdict-row {
-  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
-  &__lbl { font: 600 .65rem t.$font-mono; letter-spacing: .06em;
-           text-transform: uppercase; color: rgb(var(--fg-rgb) / .5);
-           margin-right: 4px; }
-  &--readonly .vchip { opacity: .9; cursor: default; }
-}
-.vchip {
-  display: inline-flex; align-items: center; gap: 4px;
-  padding: 4px 10px; border-radius: 999px;
-  font: 600 .72rem t.$font-mono;
-  border: 1px solid transparent;
-  background: rgb(var(--fg-rgb) / .05);
-  color: rgb(var(--fg-rgb) / .55);
-  cursor: pointer; transition: all .12s;
-  &:hover { background: rgb(var(--fg-rgb) / .1); }
-  &--compliant.vchip--on   { background: rgb(var(--success-rgb)); color: #fff;
-                              border-color: rgb(var(--success-rgb)); }
-  &--observation.vchip--on { background: rgb(var(--warning-rgb)); color: #fff;
-                              border-color: rgb(var(--warning-rgb)); }
-  &--nc.vchip--on          { background: rgb(var(--danger-rgb)); color: #fff;
-                              border-color: rgb(var(--danger-rgb)); }
-  &--na.vchip--on          { background: rgb(var(--fg-rgb) / .25); color: #fff;
-                              border-color: rgb(var(--fg-rgb) / .25); }
-}
-
-.center-nav {
-  display: flex; justify-content: space-between; gap: 10px;
-  padding-top: 10px;
-}
-
-// ── RIGHT: auditor deck ─────────────────────────────────
-.ws-deck {
-  display: flex; flex-direction: column; gap: 12px;
-  overflow-y: auto; padding-right: 4px;
-}
-.deck-section {
-  display: flex; flex-direction: column; gap: 8px;
-  padding: 12px; border-radius: 12px;
-  background: rgb(var(--bg-card-rgb) / .7);
-  border: 1px solid rgb(var(--accent-rgb) / .14);
-  &__head { display: flex; align-items: center; justify-content: space-between; }
-  &__title { font: 700 .8rem t.$font-display; color: rgb(var(--fg-strong-rgb));
-             letter-spacing: .01em; }
-  &__add {
-    background: transparent; border: 1px solid rgb(var(--accent-rgb) / .3);
-    color: var(--color-btn-add, #059669);
-    padding: 3px 10px; border-radius: 6px; cursor: pointer;
-    font: 600 .72rem t.$font-mono;
-    &:hover:not(:disabled) { background: var(--color-btn-add, #059669); color: #fff;
-                              border-color: var(--color-btn-add, #059669); }
-    &:disabled { opacity: .4; cursor: not-allowed; }
-  }
-  &__sub { font: 600 .65rem t.$font-mono; color: rgb(var(--fg-rgb) / .5); }
-}
-.deck-empty {
-  font-size: .76rem; color: rgb(var(--fg-rgb) / .45);
-  padding: 8px 4px; font-style: italic;
-}
-.finding, .rec {
-  display: flex; flex-direction: column; gap: 6px;
-  padding: 8px; border-radius: 8px;
-  background: rgb(var(--bg-app-rgb) / .5);
-  border: 1px solid rgb(var(--accent-rgb) / .1);
-}
-.finding__head { display: flex; align-items: center; gap: 8px; }
-.finding__sev {
-  background: rgb(var(--bg-card-rgb)); border: 1px solid rgb(var(--accent-rgb) / .2);
-  color: rgb(var(--fg-strong-rgb)); border-radius: 5px;
-  padding: 3px 6px; font: 600 .7rem t.$font-mono; cursor: pointer;
-}
-.finding__sev-dot {
-  width: 10px; height: 10px; border-radius: 50%;
-  &--low      { background: rgb(var(--success-rgb)); }
-  &--medium   { background: rgb(var(--warning-rgb)); }
-  &--high     { background: #ea580c; }
-  &--critical { background: rgb(var(--danger-rgb)); }
-}
-.finding__del, .rec__del {
-  margin-left: auto;
-  background: transparent; border: none; cursor: pointer;
-  color: rgb(var(--fg-rgb) / .4); font-size: 1.2rem; line-height: 1;
-  padding: 2px 6px; border-radius: 4px;
-  &:hover:not(:disabled) { color: rgb(var(--danger-rgb)); background: rgb(var(--danger-rgb) / .1); }
-  &:disabled { opacity: .3; cursor: not-allowed; }
-}
-.finding__text, .rec__text, .deck-note {
-  width: 100%; resize: vertical;
-  padding: 8px 10px; border-radius: 6px;
-  background: rgb(var(--bg-card-rgb));
-  border: 1px solid rgb(var(--accent-rgb) / .15);
-  color: rgb(var(--fg-strong-rgb));
-  font: 400 .82rem t.$font-body; line-height: 1.5;
-  &:focus { outline: none; border-color: var(--color-btn-add, #059669);
-            box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-btn-add, #059669) 14%, transparent); }
-}
-/* Findings/recommendations often hold multi-line AI-inserted text — give them
-   room to read without forcing the user to expand every box manually. */
-.finding__text, .rec__text { min-height: 92px; }
-.rec { flex-direction: row; align-items: flex-start; gap: 4px; }
-.rec__text { flex: 1; }
-
-/* ══ Phase 3: Evidence Drawer ══ */
 .ws-drawer-backdrop {
   position: fixed; inset: 0; background: rgb(0 0 0 / .35);
   z-index: 1900; animation: ws-drawer-fade .18s ease-out;
@@ -1247,7 +958,6 @@
   white-space: pre-wrap; word-break: break-word;
   overflow: auto;
 
-  // Relevance shading — soft (level 1) vs strong (level 2) by semantic score.
   .ocr-hl {
     border-radius: 2px; padding: 0 1px;
     color: rgb(var(--fg-strong-rgb));
@@ -1358,9 +1068,9 @@
   &:active { transform: translateY(1px); }
 }
 
-/* ═══════════════════════════════════════════════════════════════════
-   Phase 4 — RICS clause linking on findings
-   ═══════════════════════════════════════════════════════════════════ */
+// ═══════════════════════════════════════════════════════════════════
+// Phase 4 — RICS clause linking on findings
+// ═══════════════════════════════════════════════════════════════════
 
 .clause-row {
   display: flex;
@@ -1549,14 +1259,15 @@
     line-height: 1.35;
     display: -webkit-box;
     -webkit-line-clamp: 2;
+    line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
 }
 
-/* ═══════════════════════════════════════════════════════════════════
-   Phase 5 — AI suggestion actions
-   ═══════════════════════════════════════════════════════════════════ */
+// ═══════════════════════════════════════════════════════════════════
+// Phase 5 — AI suggestion actions
+// ═══════════════════════════════════════════════════════════════════
 
 .ai-suggest-list {
   list-style: none;
@@ -1628,3 +1339,5 @@
     }
   }
 }
+.ws-drawer__office-fallback { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; padding: 60px 20px; color: rgb(var(--fg-rgb) / .7); text-align: center; }
+.ws-drawer__office-download { padding: 8px 16px; border-radius: 8px; background: rgb(var(--accent-rgb)); color: white; text-decoration: none; font-weight: 600; }

--- a/src/app/admin/audit-workspace/audit-workspace.component.scss
+++ b/src/app/admin/audit-workspace/audit-workspace.component.scss
@@ -1341,3 +1341,43 @@
 }
 .ws-drawer__office-fallback { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; padding: 60px 20px; color: rgb(var(--fg-rgb) / .7); text-align: center; }
 .ws-drawer__office-download { padding: 8px 16px; border-radius: 8px; background: rgb(var(--accent-rgb)); color: white; text-decoration: none; font-weight: 600; }
+
+/* ── Findings & Recommendations: collapsible bottom drawer (toggle) ── */
+.ws-deck-bottom-wrapper {
+  max-height: 2000px;
+  overflow: hidden;
+  transition: max-height 0.4s ease-in-out;
+}
+
+.ws-deck-bottom-wrapper.collapsed {
+  max-height: 0;
+}
+
+.bottom-toggle-wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 8px 0;
+}
+
+.bottom-toggle-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 16px;
+  font-size: 14px;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  color: rgb(var(--fg-rgb) / .85);
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.bottom-toggle-btn:hover {
+  background: rgb(var(--fg-rgb) / .06);
+}
+
+.bottom-toggle-btn .btn-icon {
+  font-size: 12px;
+  transition: transform 0.2s;
+}

--- a/src/app/admin/audit-workspace/audit-workspace.component.ts
+++ b/src/app/admin/audit-workspace/audit-workspace.component.ts
@@ -468,6 +468,28 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return Object.keys(map).length;
   }
 
+  // ─── NEW: Verdict completion validation ────────────────────────────
+  isStepFullyVerdicted(step: WorkspaceStep): boolean {
+    const answers = this.answersForStep(step);
+    if (answers.length === 0) return true;
+    const stepVerdicts = this.verdicts[step.id] || {};
+    for (const ans of answers) {
+      if (!stepVerdicts[ans.fieldId]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  getUnansweredQuestions(step: WorkspaceStep): string[] {
+    const answers = this.answersForStep(step);
+    const stepVerdicts = this.verdicts[step.id] || {};
+    return answers
+      .filter(a => !stepVerdicts[a.fieldId])
+      .map(a => a.fieldLabel || `Question ${a.fieldId}`);
+  }
+  // ──────────────────────────────────────────────────────────────────
+
   get overallProgress(): number {
     if (!this.steps.length) return 0;
     const touched = this.steps.filter(s => this.stepRollup(s) !== 'pending').length;
@@ -768,6 +790,17 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
 
   // ── Navigation ──────────────────────────────────────────────────
   async goToStep(idx: number): Promise<void> {
+    // ── NEW: validate forward navigation ──────────────────────────
+    if (idx > this.activeStep && this.request?.status !== 'COMPLETED') {
+      const current = this.currentStep;
+      if (current && !this.isStepFullyVerdicted(current)) {
+        const unanswered = this.getUnansweredQuestions(current);
+        this.flash(`Please provide a verdict for all questions before moving on: ${unanswered.join(', ')}`, true);
+        this.cdr.detectChanges();
+        return;
+      }
+    }
+
     if (!this.request || this.request?.status === 'COMPLETED') {
       this.activeStep = idx;
       this.ensureAiSuggestions(this.currentStep);

--- a/src/app/admin/audit-workspace/audit-workspace.component.ts
+++ b/src/app/admin/audit-workspace/audit-workspace.component.ts
@@ -101,6 +101,8 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
   showChat = false;
   allQuestionsCollapsed = false;
   isRailCollapsed = false;
+  isExporting = false;
+  bottomDeckExpanded = true;
 
   // verdicts[stepId][fieldId] = verdict
   verdicts:        Record<number, Record<number, Verdict>> = {};
@@ -186,6 +188,10 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
 
   toggleRail(): void {
     this.isRailCollapsed = !this.isRailCollapsed;
+  }
+
+  toggleBottomDeck(): void {
+    this.bottomDeckExpanded = !this.bottomDeckExpanded;
   }
 
   toggleChat(): void {
@@ -724,6 +730,39 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
           this.flash('Failed to complete audit.', true);
         }
       });
+    });
+  }
+
+  /** Download a server-generated PDF report for the completed audit. */
+  exportReport(): void {
+    if (!this.request) return;
+    this.isExporting = true;
+
+    const token = this.tokenSvc.getToken();
+    const headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
+    const url = `${environment.apiUrl}/audits/${this.request.id}/report`;
+
+    this.http.get(url, { headers, responseType: 'blob' }).subscribe({
+      next: (blob) => {
+        const objectUrl = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = objectUrl;
+        link.download = `audit_${this.request!.id}_report.pdf`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(objectUrl);
+
+        this.isExporting = false;
+        this.flash('Report downloaded successfully.', false);
+        this.cdr.detectChanges();
+      },
+      error: (err) => {
+        log.error(LOG, 'export report failed', err);
+        this.isExporting = false;
+        this.flash('Failed to generate report.', true);
+        this.cdr.detectChanges();
+      }
     });
   }
 

--- a/src/app/admin/audit-workspace/audit-workspace.component.ts
+++ b/src/app/admin/audit-workspace/audit-workspace.component.ts
@@ -2,7 +2,6 @@ import {
   Component, OnInit, OnDestroy, inject, ChangeDetectorRef, ViewChild, ElementRef
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ChatComponent } from '../../features/chat/chat.component';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
@@ -14,36 +13,29 @@ import { AuditProcessStepService, AuditProcessStep } from '../../services/audit-
 import { AuditStepResultService, AuditStepResult } from '../../services/audit-step-result.service';
 import { TokenService } from '../../shared/token.service';
 import { AuditBotComponent } from '../../layout/audit-bot/audit-bot.component';
-import { AuditRequest , AuditRequestAnswer } from '../../models/audit.model';
+import { AuditRequest } from '../../models/audit.model';
 import { environment } from '../../environments/environment';
 import { RicsSearchService, RicsRuleResult, RicsEvidenceItem, RelevanceSegment } from '../../services/rics-search.service';
 import { log } from '../../core/logging/log';
 
 const LOG = 'ng.audit-workspace';
-/**
- * Unified step model used by the workspace stepper.
- * Built from intake form steps (preferred — they carry the actual fields)
- * or from auditor process steps (fallback when no form template is available).
- */
+
 interface WorkspaceStep {
-  id:        number;        // intake form step id, or -1 for synthetic fallback
+  id:        number;
   name:      string;
   stepOrder: number;
-  fieldIds:  number[];      // empty array => show all answers (fallback mode)
+  fieldIds:  number[];
   isDefault?: boolean;
 }
 
-/** Auditor's per-question verdict. */
 export type Verdict = 'compliant' | 'observation' | 'non-conformity' | 'na';
-
-/** Step-level roll-up derived from per-question verdicts. */
 export type StepRollup = 'pending' | 'compliant' | 'partial' | 'non-compliant';
 
 export interface RicsClauseRef {
   ruleId:        string;
   section?:      string;
   shortTitle?:   string;
-  requirement?:  string;   // short snippet for tooltip / context
+  requirement?:  string;
 }
 
 export interface Finding {
@@ -51,6 +43,7 @@ export interface Finding {
   severity:    'low' | 'medium' | 'high' | 'critical';
   description: string;
   clauses?:    RicsClauseRef[];
+  note?: string;
 }
 
 export interface Recommendation {
@@ -58,9 +51,8 @@ export interface Recommendation {
   description: string;
 }
 
-/** Persisted alongside the step's description as a hidden HTML-comment block. */
 interface StepMeta {
-  verdicts:        Record<number, Verdict>;   // keyed by fieldId
+  verdicts:        Record<number, Verdict>;
   findings:        Finding[];
   recommendations: Recommendation[];
 }
@@ -68,7 +60,6 @@ interface StepMeta {
 const META_OPEN  = '<!--AUDIT_META_V1:';
 const META_CLOSE = ':END-->';
 
-/** OCR row returned by GET /api/v1/audits/{id}/ocr. */
 interface OcrResult {
   id:             number;
   auditRequestId: number;
@@ -95,6 +86,7 @@ interface OcrResult {
 })
 export class AuditWorkspaceComponent implements OnInit, OnDestroy {
 
+  // ── Public properties ──────────────────────────────────────────────
   request:     AuditRequest | null = null;
   steps:       WorkspaceStep[]     = [];
   results:     AuditStepResult[]   = [];
@@ -107,56 +99,62 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
 
   drafts: Record<number, string> = {};
   showChat = false;
+  allQuestionsCollapsed = false;
+  isRailCollapsed = false;
 
-  toggleChat(): void {
-    this.showChat = !this.showChat;
-  }
-  // ── Phase 2: per-question verdicts + findings/recs (per step) ──────
-  /** verdicts[stepId][fieldId] = verdict */
+  // verdicts[stepId][fieldId] = verdict
   verdicts:        Record<number, Record<number, Verdict>> = {};
   findings:        Record<number, Finding[]>        = {};
   recommendations: Record<number, Recommendation[]> = {};
 
+  // ── OCR / file viewer ──────────────────────────────────────────────
   showFileViewer   = false;
   viewingFileUrl:  SafeResourceUrl | null = null;
   viewingFileName: string | null = null;
   isLoadingFile    = false;
 
-  // ── OCR (extracted-text preview per evidence file) ─────────────────
   ocrByMedia: Record<number, OcrResult> = {};
   showOcrViewer = false;
   viewingOcr:   OcrResult | null = null;
   private ocrPollHandle: any = null;
 
-  // ── Phase 3: unified Evidence Drawer ───────────────────────────────
+  // ── Evidence Drawer ────────────────────────────────────────────────
   showDrawer       = false;
   drawerMedia:     { id: number; url: string; name: string } | null = null;
   drawerMediaIndex = 0;
-  drawerQuery      = '';   // the audit question this evidence is meant to prove
+  drawerQuery      = '';
   drawerTab:       'preview' | 'ocr' = 'preview';
   drawerLoading    = false;
   drawerBlobUrl:   SafeResourceUrl | null = null;
   private drawerObjectUrl: string | null = null;
 
-  // ── Phase 4: RICS clause picker (per-finding) ──────────────────────
-  pickerOpenFor: string | null = null;     // finding.id currently picking
+  // ── Clause picker ──────────────────────────────────────────────────
+  pickerOpenFor: string | null = null;
   pickerQuery   = '';
   pickerLoading = false;
   pickerResults: RicsRuleResult[] = [];
   private pickerDebounce: any = null;
 
-  // ── Phase 5: dismissed AI suggestions (per-step, session-only) ─────
+  // ── AI suggestions ────────────────────────────────────────────────
   dismissedSuggestions: Record<number, Set<string>> = {};
-
-  // ── Grounded AI suggestions fetched from the RAG /rules/evidence-check ──
   private aiSuggestions: Record<number, string[]> = {};
   private aiSuggestRequested = new Set<number>();
   aiSuggestLoading: Record<number, boolean> = {};
 
-  isAuditorMode = false;
+  // ── OCR relevance ──────────────────────────────────────────────────
+  ocrHighlightOn = true;
+  ocrRelevanceLoading = false;
+  ocrRelevanceFailed  = false;
+  private _ocrHlCache: { key: string; html: SafeHtml } | null = null;
+  private ocrRelevance: Record<string, RelevanceSegment[]> = {};
+  private ocrRelevanceTruncated: Record<string, boolean> = {};
+  private ocrRelevanceRequested = new Set<string>();
+  @ViewChild('ocrTextEl') private ocrTextEl?: ElementRef<HTMLElement>;
 
+  isAuditorMode = false;
   readonly serverBase = environment.serverBaseUrl;
 
+  // ── Injected services ─────────────────────────────────────────────
   private route     = inject(ActivatedRoute);
   private router    = inject(Router);
   private reqSvc    = inject(AuditRequestService);
@@ -169,6 +167,7 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
   private cdr       = inject(ChangeDetectorRef);
   private ricsSvc   = inject(RicsSearchService);
 
+  // ── Lifecycle ──────────────────────────────────────────────────────
   ngOnInit(): void {
     this.isAuditorMode = this.router.url.includes('/auditor/');
     const id = Number(this.route.snapshot.paramMap.get('id'));
@@ -183,6 +182,90 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     this.releaseDrawerBlob();
   }
 
+  // ── Methods ──────────────────────────────────────────────────────
+
+  toggleRail(): void {
+    this.isRailCollapsed = !this.isRailCollapsed;
+  }
+
+  toggleChat(): void {
+    this.showChat = !this.showChat;
+  }
+
+  toggleAllQuestions(): void {
+    this.allQuestionsCollapsed = !this.allQuestionsCollapsed;
+    if (this.currentStepAnswers) {
+      this.currentStepAnswers.forEach(a => a.collapsed = this.allQuestionsCollapsed);
+    }
+  }
+
+  toggleQuestion(index: number): void {
+    const answer = this.currentStepAnswers?.[index];
+    if (answer) {
+      answer.collapsed = !answer.collapsed;
+    }
+  }
+
+  updateFindingNote(findingId: string, note: string): void {
+    const stepId = this.currentStep?.id;
+    if (stepId == null) return;
+    const stepFindings = this.findings[stepId] ?? [];
+    const finding = stepFindings.find(f => f.id === findingId);
+    if (finding) {
+      finding.note = note;
+    }
+  }
+
+  getEvidenceItems(answer: any): { id: number; name: string; url: string; index: number }[] {
+    const items: { id: number; name: string; url: string; index: number }[] = [];
+    let idx = 1;
+
+    const tryAdd = (obj: any) => {
+      if (!obj || typeof obj !== 'object') return;
+      const id = obj.id || obj.mediaId || obj.fileId || obj.attachmentId;
+      if (!id) return;
+      const name = obj.name || obj.fileName || obj.mediaName || obj.attachmentName || `Evidence ${idx}`;
+      const url = obj.url || obj.fileUrl || obj.mediaUrl || '';
+      items.push({ id, name, url, index: idx++ });
+    };
+
+    if (answer.fileMedia) {
+      tryAdd(answer.fileMedia);
+    }
+    if (Array.isArray(answer.files)) {
+      for (const f of answer.files) {
+        tryAdd(f.media || f.file || f);
+      }
+    }
+
+    const extraProps = ['evidence', 'attachments', 'documents', 'media', 'filesList'];
+    for (const prop of extraProps) {
+      const val = answer[prop];
+      if (Array.isArray(val)) {
+        for (const item of val) {
+          tryAdd(item);
+        }
+      } else if (val && typeof val === 'object') {
+        tryAdd(val);
+      }
+    }
+
+    for (const key of Object.keys(answer)) {
+      if (['fileMedia', 'files', ...extraProps].includes(key)) continue;
+      const val = answer[key];
+      if (Array.isArray(val) && val.length > 0 && typeof val[0] === 'object') {
+        for (const item of val) {
+          tryAdd(item);
+        }
+      } else if (val && typeof val === 'object' && val.id) {
+        tryAdd(val);
+      }
+    }
+
+    return items;
+  }
+
+  // ── Load data ─────────────────────────────────────────────────────
   loadRequest(id: number): void {
     const request$ = this.isAuditorMode
       ? this.reqSvc.auditorGetAuditById(id)
@@ -192,17 +275,8 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     request$.subscribe({
       next: req => {
         this.request = req;
-        log.info(LOG, 'audit loaded', { id, type: req.auditType, status: req.status });
-
-        if (req.status === 'ASSIGNED') {
-          this.autoStart(id);
-        }
-
-        // Load intake form template — each form step becomes a workspace step.
-        // This gives the stepper meaningful navigation (Prev/Next across each
-        // intake section) AND exact per-step answer filtering by fieldId.
+        if (req.status === 'ASSIGNED') this.autoStart(id);
         this.loadFormSteps(req.auditType);
-
         this.loadResults(id);
         this.loadOcr(id);
         this.cdr.detectChanges();
@@ -219,8 +293,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
           .sort((a, b) => (a.stepOrder ?? 0) - (b.stepOrder ?? 0));
 
         if (formSteps.length > 0) {
-          // Only surface steps that actually carry a mapped customer response —
-          // the auditor/admin workspace shouldn't list empty intake sections.
           this.steps = formSteps
             .map(s => ({
               id:        s.id,
@@ -231,13 +303,10 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
             .filter(s => this.answersForStep(s).length > 0);
 
           if (this.steps.length === 0) {
-            // Template exists but nothing mapped — fall back so the workspace
-            // isn't left empty.
             this.loadStepsByAuditType(auditType);
             return;
           }
         } else {
-          // No intake form steps — fall back to auditor process steps.
           this.loadStepsByAuditType(auditType);
           return;
         }
@@ -245,7 +314,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
         this.steps.forEach(s => {
           if (this.drafts[s.id] === undefined) this.drafts[s.id] = '';
         });
-        // Re-apply any results that loaded before steps were ready.
         this.applyResultsToDrafts();
         this.ensureAiSuggestions(this.currentStep);
         this.cdr.detectChanges();
@@ -254,7 +322,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     });
   }
 
-  // Fallback when no intake form template exists.
   private loadStepsByAuditType(auditType: string): void {
     this.reqSvc.getProcessStepsByAuditType(auditType, this.isAuditorMode).subscribe({
       next: steps => {
@@ -311,7 +378,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** Match results to current steps by stepName (resilient when results load before steps). */
   private applyResultsToDrafts(): void {
     if (!this.steps.length || !this.results.length) return;
     for (const r of this.results) {
@@ -325,12 +391,10 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     }
   }
 
-  // ── Meta (de)serialization ───────────────────────────────────────
   private emptyMeta(): StepMeta {
     return { verdicts: {}, findings: [], recommendations: [] };
   }
 
-  /** Split a stored description into the visible note and the hidden meta block. */
   private parseStepBody(body: string): { note: string; meta: StepMeta } {
     const i = body.indexOf(META_OPEN);
     if (i === -1) return { note: body, meta: this.emptyMeta() };
@@ -346,12 +410,11 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
         findings:        parsed.findings        ?? [],
         recommendations: parsed.recommendations ?? []
       };
-    } catch { /* ignore malformed */ }
+    } catch { /* ignore */ }
     const note = (body.substring(0, i) + body.substring(j + META_CLOSE.length)).trim();
     return { note, meta };
   }
 
-  /** Re-build the description string from the step note + meta state. */
   private composeStepBody(stepId: number): string {
     const note = (this.drafts[stepId] ?? '').trim();
     const meta: StepMeta = {
@@ -376,7 +439,7 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     if (this.request?.status === 'COMPLETED') return;
     if (!this.verdicts[stepId]) this.verdicts[stepId] = {};
     if (this.verdicts[stepId][fieldId] === v) {
-      delete this.verdicts[stepId][fieldId]; // toggle off
+      delete this.verdicts[stepId][fieldId];
       log.info(LOG, 'verdict cleared', { stepId, fieldId });
     } else {
       this.verdicts[stepId][fieldId] = v;
@@ -385,7 +448,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     this.cdr.detectChanges();
   }
 
-  /** Roll-up of per-question verdicts into a step-level status. */
   stepRollup(step: WorkspaceStep): StepRollup {
     const map = this.verdicts[step.id] ?? {};
     const vals = Object.values(map);
@@ -395,20 +457,17 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return 'compliant';
   }
 
-  /** Number of questions in the step that have been verdicted. */
   stepVerdictedCount(step: WorkspaceStep): number {
     const map = this.verdicts[step.id] ?? {};
     return Object.keys(map).length;
   }
 
-  /** Overall progress across all steps (% of steps with any verdict). */
   get overallProgress(): number {
     if (!this.steps.length) return 0;
     const touched = this.steps.filter(s => this.stepRollup(s) !== 'pending').length;
     return Math.round((touched / this.steps.length) * 100);
   }
 
-  /** Counts of findings across all steps. */
   get totalFindings(): number {
     return Object.values(this.findings).reduce((n, arr) => n + arr.length, 0);
   }
@@ -489,6 +548,7 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     if (r) { r.description = text; }
   }
 
+  // ── Getters ──────────────────────────────────────────────────────
   get currentStep(): WorkspaceStep | null {
     return this.steps[this.activeStep] ?? null;
   }
@@ -507,7 +567,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     if (this.currentStep) this.drafts[this.currentStep.id] = val;
   }
 
-  /** Public helper for templates: true if current step has any saveable content. */
   hasCurrentContent(): boolean {
     return !!this.currentStep && this.hasStepContent(this.currentStep.id);
   }
@@ -519,8 +578,8 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     );
   }
 
- saveDraft(): void { this.persist('DRAFT'); }
- // saveResult(): void { this.persist('SAVED'); }
+  // ── Save / persist ──────────────────────────────────────────────
+  saveDraft(): void { this.persist('DRAFT'); }
 
   deleteCurrentResult(): void {
     const existing = this.currentResult;
@@ -544,6 +603,152 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return 'pending';
   }
 
+  // ── Persist helpers ─────────────────────────────────────────────
+  private hasStepContent(stepId: number): boolean {
+    if ((this.drafts[stepId] ?? '').trim()) return true;
+    if (Object.keys(this.verdicts[stepId] ?? {}).length) return true;
+    if ((this.findings[stepId] ?? []).length) return true;
+    if ((this.recommendations[stepId] ?? []).length) return true;
+    return false;
+  }
+
+  private persistAsync(status: 'DRAFT' | 'SAVED'): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this.request || !this.currentStep) { resolve(); return; }
+      const step     = this.currentStep;
+      const desc     = this.composeStepBody(step.id);
+      const existing = this.currentResult;
+
+      if (!this.hasStepContent(step.id)) { resolve(); return; }
+
+      const payload = {
+        processStepId: -1,
+        stepName:      step.name,
+        description:   desc,
+        status
+      };
+
+      const obs = existing
+        ? this.resSvc.update(this.request.id, existing.id, payload)
+        : this.resSvc.saveOrUpdate(this.request.id, payload);
+
+      obs.subscribe({
+        next: result => {
+          const idx = this.results.findIndex(r => r.id === result.id);
+          if (idx !== -1) this.results[idx] = result;
+          else this.results.push(result);
+          this.cdr.detectChanges();
+          resolve();
+        },
+        error: () => resolve()
+      });
+    });
+  }
+
+  private persist(status: 'DRAFT' | 'SAVED'): void {
+    if (!this.request || !this.currentStep) return;
+    this.isSaving = true;
+    const step     = this.currentStep;
+    const desc     = this.composeStepBody(step.id);
+    const existing = this.currentResult;
+
+    const payload = {
+      processStepId: -1,
+      stepName:      step.name,
+      description:   desc,
+      status
+    };
+
+    const obs = existing
+      ? this.resSvc.update(this.request.id, existing.id, payload)
+      : this.resSvc.saveOrUpdate(this.request.id, payload);
+
+    obs.subscribe({
+      next: result => {
+        const idx = this.results.findIndex(r => r.id === result.id);
+        if (idx !== -1) this.results[idx] = result;
+        else this.results.push(result);
+        this.isSaving = false;
+        this.flash(status === 'DRAFT' ? 'Draft saved.' : 'Step saved.', false);
+        this.cdr.detectChanges();
+      },
+      error: () => {
+        this.isSaving = false;
+        this.flash('Failed to save.', true);
+      }
+    });
+  }
+
+  // ── Submit ──────────────────────────────────────────────────────
+  submitAudit(): void {
+    if (!this.request) return;
+    log.info(LOG, 'submit audit', { id: this.request.id, steps: this.steps.length });
+    this.isCompleting = true;
+
+    const savePromises = this.steps
+      .filter(s => this.hasStepContent(s.id))
+      .map(s => new Promise<void>((resolve) => {
+        const existing = this.results.find(r => r.stepName === s.name);
+        const payload = {
+          processStepId: -1,
+          stepName:      s.name,
+          description:   this.composeStepBody(s.id),
+          status:        'SAVED' as const
+        };
+        const obs = existing
+          ? this.resSvc.update(this.request!.id, existing.id, payload)
+          : this.resSvc.saveOrUpdate(this.request!.id, payload);
+        obs.subscribe({ next: result => {
+          const idx = this.results.findIndex(r => r.id === result.id);
+          if (idx !== -1) this.results[idx] = result;
+          else this.results.push(result);
+          resolve();
+        }, error: () => resolve() });
+      }));
+
+    Promise.all(savePromises).then(() => {
+      const complete$ = this.isAuditorMode
+        ? this.reqSvc.auditorCompleteAudit(this.request!.id)
+        : this.reqSvc.adminCompleteRequest(this.request!.id);
+
+      complete$.subscribe({
+        next: updated => {
+          this.request      = updated;
+          this.isCompleting = false;
+          this.flash('Audit completed successfully!', false);
+          setTimeout(() => this.goBack(), 1500);
+          this.cdr.detectChanges();
+        },
+        error: () => {
+          this.isCompleting = false;
+          this.flash('Failed to complete audit.', true);
+        }
+      });
+    });
+  }
+
+  // ── Navigation ──────────────────────────────────────────────────
+  async goToStep(idx: number): Promise<void> {
+    if (!this.request || this.request?.status === 'COMPLETED') {
+      this.activeStep = idx;
+      this.ensureAiSuggestions(this.currentStep);
+      return;
+    }
+    if (this.currentStep && this.hasStepContent(this.currentStep.id)) {
+      await this.persistAsync('DRAFT');
+    }
+    this.activeStep = idx;
+    this.ensureAiSuggestions(this.currentStep);
+    this.cdr.detectChanges();
+  }
+
+  goBack(): void {
+    this.router.navigate(
+      this.isAuditorMode ? ['/auditor/audits'] : ['/admin/audits']
+    );
+  }
+
+  // ── File viewer ──────────────────────────────────────────────────
   openFileViewer(url: string, name: string): void {
     this.viewingFileName = name;
     this.viewingFileUrl  = null;
@@ -568,14 +773,19 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     });
   }
 
+  isOfficeDocument(name: string): boolean {
+    const officeExts = ['doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx'];
+    const ext = name.split('.').pop()?.toLowerCase() || '';
+    return officeExts.includes(ext);
+  }
+
   closeFileViewer(): void {
     this.showFileViewer  = false;
     this.viewingFileUrl  = null;
     this.viewingFileName = null;
   }
 
-  // ── OCR ────────────────────────────────────────────────────────────
-  /** Fetch all OCR rows for the audit and index them by mediaId. */
+  // ── OCR ──────────────────────────────────────────────────────────
   loadOcr(auditId: number, scheduleNext = true): void {
     const token   = this.tokenSvc.getToken();
     const headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
@@ -596,7 +806,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** Re-poll every 4s while any row is PENDING/RUNNING. Stops once all done/failed. */
   private scheduleOcrPoll(auditId: number): void {
     if (this.ocrPollHandle) {
       clearTimeout(this.ocrPollHandle);
@@ -605,8 +814,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     const pending = Object.values(this.ocrByMedia).some(
       r => r.status === 'PENDING' || r.status === 'RUNNING'
     );
-    // Always re-poll at least once after first load — fresh submits may not
-    // have created rows yet.
     const empty = Object.keys(this.ocrByMedia).length === 0;
     if (pending || empty) {
       this.ocrPollHandle = setTimeout(
@@ -619,10 +826,8 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return this.ocrByMedia[mediaId] ?? null;
   }
 
-  /** Friendly evidence label: temp UUID filenames become "Evidence N". */
   displayName(name: string | undefined | null, index = 0): string {
     if (!name) return `Evidence ${index}`;
-    // UUID pattern: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (filenames are prefixed with one)
     const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(name);
     return isUuid ? `Evidence ${index}` : name;
   }
@@ -638,7 +843,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return 'Extracted text';
   }
 
-  /** Fuller tooltip for the evidence text badge. */
   ocrTitle(r: OcrResult | null): string {
     if (!r) return 'Text extraction is queued for this document';
     switch (r.status) {
@@ -650,31 +854,43 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return 'View extracted text';
   }
 
-  // ── Evidence relevance highlight (OCR text tab) ──────────────────
-  /** Toggle for shading question-relevant lines in the extracted text. */
-  ocrHighlightOn = true;
-  ocrRelevanceLoading = false;
-  ocrRelevanceFailed  = false;   // drives keyword fallback
-  private _ocrHlCache: { key: string; html: SafeHtml } | null = null;
-  private ocrRelevance: Record<string, RelevanceSegment[]> = {};
-  private ocrRelevanceTruncated: Record<string, boolean> = {};
-  private ocrRelevanceRequested = new Set<string>();
-  @ViewChild('ocrTextEl') private ocrTextEl?: ElementRef<HTMLElement>;
+  isRetryable(r: OcrResult | null): boolean {
+    return !!r && r.status === 'FAILED';
+  }
 
+  retryOcr(mediaId: number | undefined | null, ev?: Event): void {
+    if (ev) ev.stopPropagation();
+    if (mediaId == null || !this.request) return;
+    const token   = this.tokenSvc.getToken();
+    const headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
+    const url = `${environment.apiUrl}/audits/${this.request.id}/ocr/media/${mediaId}/retry`;
+    this.http.post<OcrResult>(url, {}, { headers }).subscribe({
+      next: row => {
+        this.ocrByMedia[row.mediaId] = row;
+        this.cdr.detectChanges();
+        if (this.request) this.scheduleOcrPoll(this.request.id);
+      }
+    });
+  }
+
+  ocrClass(r: OcrResult | null): string {
+    if (!r) return 'ocr-badge ocr-badge--pending';
+    switch (r.status) {
+      case 'DONE':    return 'ocr-badge ocr-badge--done';
+      case 'FAILED':  return 'ocr-badge ocr-badge--failed';
+      default:        return 'ocr-badge ocr-badge--pending';
+    }
+  }
+
+  // ── Evidence relevance ──────────────────────────────────────────
   private relevanceKey(mediaId: number, query: string): string {
     return `${mediaId}|${query}`;
   }
 
-  /** The relevance target for the open evidence: the answered question. */
   private get drawerRelevanceQuery(): string {
     return (this.drawerQuery || this.currentStep?.name || '').trim();
   }
 
-  /**
-   * Fetch sentence-level semantic relevance for the open evidence against its
-   * audit question. Idempotent per (file, question); on failure the renderer
-   * silently falls back to keyword highlighting.
-   */
   ensureRelevance(): void {
     const media = this.drawerMedia;
     const o = this.drawerOcr();
@@ -692,13 +908,13 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
         this.ocrRelevance[key] = res?.segments ?? [];
         this.ocrRelevanceTruncated[key] = !!res?.truncated;
         this.ocrRelevanceLoading = false;
-        this._ocrHlCache = null;            // bust render cache
+        this._ocrHlCache = null;
         log.info(LOG, 'relevance scored', { segments: res?.segments?.length ?? 0, truncated: !!res?.truncated });
         this.cdr.detectChanges();
       },
       error: () => {
         this.ocrRelevanceLoading = false;
-        this.ocrRelevanceFailed  = true;    // renderer uses keyword fallback
+        this.ocrRelevanceFailed  = true;
         log.warn(LOG, 'relevance unavailable — using keyword fallback', { mediaId: media.id });
         this.ocrRelevanceRequested.delete(key);
         this._ocrHlCache = null;
@@ -707,14 +923,12 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** True once semantic segments are available for the open evidence. */
   get hasSemanticRelevance(): boolean {
     const media = this.drawerMedia;
     if (!media) return false;
     return (this.ocrRelevance[this.relevanceKey(media.id, this.drawerRelevanceQuery)]?.length ?? 0) > 0;
   }
 
-  /** Number of "most relevant" (strong) sentences in the open evidence. */
   get strongRelevanceCount(): number {
     const media = this.drawerMedia;
     if (!media) return 0;
@@ -722,23 +936,16 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return segs.filter(s => s.level >= 2).length;
   }
 
-  /** True when the document was too long and was scored only up to the cap. */
   get relevanceTruncated(): boolean {
     const media = this.drawerMedia;
     return !!media && !!this.ocrRelevanceTruncated[this.relevanceKey(media.id, this.drawerRelevanceQuery)];
   }
 
-  /** Scroll the extracted-text pane to the first strongly-relevant line. */
   jumpToMostRelevant(): void {
     const el = this.ocrTextEl?.nativeElement?.querySelector('.ocr-hl--2');
     el?.scrollIntoView({ block: 'center', behavior: 'smooth' });
   }
 
-  /**
-   * Render the OCR text with the most question-relevant sentences shaded.
-   * Prefers semantic segments (offsets from the RAG service); falls back to
-   * keyword marking while loading or if the relevance service is unreachable.
-   */
   highlightedOcrText(text: string): SafeHtml {
     const media = this.drawerMedia;
     const query = this.drawerRelevanceQuery;
@@ -755,7 +962,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return safe;
   }
 
-  /** Wrap the highest-scoring sentence spans (by char offset) in <mark>. */
   private buildSemanticHtml(text: string, segs: RelevanceSegment[]): string {
     const marks = segs.filter(s => s.level > 0).sort((a, b) => a.start - b.start);
     let out = '';
@@ -772,7 +978,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return out;
   }
 
-  /** Offline fallback: mark question keywords in the text. */
   private buildKeywordHtml(text: string): string {
     const keywords = this.relevanceKeywords();
     let html = this.escapeHtml(text);
@@ -788,7 +993,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return html;
   }
 
-  /** Meaningful terms from the step name + its question labels. */
   private relevanceKeywords(): string[] {
     const stop = new Set([
       'the','and','for','that','with','this','have','are','was','from','your','firm',
@@ -808,93 +1012,59 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   }
 
-  ocrClass(r: OcrResult | null): string {
-    if (!r) return 'ocr-badge ocr-badge--pending';
-    switch (r.status) {
-      case 'DONE':    return 'ocr-badge ocr-badge--done';
-      case 'FAILED':  return 'ocr-badge ocr-badge--failed';
-      default:        return 'ocr-badge ocr-badge--pending';
+  toggleOcrHighlight(): void {
+    this.ocrHighlightOn = !this.ocrHighlightOn;
+    this._ocrHlCache = null;
+    if (this.ocrHighlightOn) this.ensureRelevance();
+  }
+
+  /**
+   * Libère l'URL de l'objet blob précédent pour éviter les fuites mémoire
+   */
+  private releaseDrawerBlob(): void {
+    if (this.drawerObjectUrl) {
+      try {
+        URL.revokeObjectURL(this.drawerObjectUrl);
+      } catch (e) {
+        // Ignorer les erreurs de révocation
+      }
+      this.drawerObjectUrl = null;
     }
   }
 
-  openOcrViewer(mediaId: number | undefined | null): void {
-    const r = this.ocrFor(mediaId);
-    if (!r) return;
-    this.viewingOcr   = r;
-    this.showOcrViewer = true;
-  }
-
-  closeOcrViewer(): void {
-    this.showOcrViewer = false;
-    this.viewingOcr   = null;
-  }
-
-  /** Re-queue OCR for a single evidence file. */
-  retryOcr(mediaId: number | undefined | null, ev?: Event): void {
-    if (ev) ev.stopPropagation();
-    if (mediaId == null || !this.request) return;
-    const token   = this.tokenSvc.getToken();
-    const headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
-    const url = `${environment.apiUrl}/audits/${this.request.id}/ocr/media/${mediaId}/retry`;
-    this.http.post<OcrResult>(url, {}, { headers }).subscribe({
-      next: row => {
-        this.ocrByMedia[row.mediaId] = row;
-        this.cdr.detectChanges();
-        if (this.request) this.scheduleOcrPoll(this.request.id);
-      }
-    });
-  }
-
-  /** True when the badge should act as a Retry button (failed or stuck). */
-  isRetryable(r: OcrResult | null): boolean {
-    return !!r && r.status === 'FAILED';
-  }
-
-  // ── Phase 3: Evidence Drawer ──────────────────────────────────────
   /**
-   * Open the unified evidence drawer for a file: shows preview (image / PDF /
-   * generic) + OCR text + one-click "Link to finding". Replaces the older
-   * separate file viewer + OCR modal flows for evidence chips.
+   * Retourne le résultat OCR du fichier actuellement affiché dans le drawer
    */
-  openEvidence(media: { id: number; url: string; name: string },
-               index = 0,
-               query = '',
-               tab: 'preview' | 'ocr' = 'preview'): void {
-    log.info(LOG, 'open evidence', { name: this.displayName(media.name, index), tab });
-    this.releaseDrawerBlob();
-    this.drawerMedia      = media;
-    this.drawerMediaIndex = index;
-    this.drawerQuery      = query;
-    this.drawerTab     = tab;
-    this.showDrawer    = true;
-    this.drawerLoading = true;
-    this.drawerBlobUrl = null;
-    if (tab === 'ocr') this.ensureRelevance();
-
-    const token   = this.tokenSvc.getToken();
-    const headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
-    const full    = this.getFileUrl(media.url);
-    console.log('Fetching file:', full);
-
-    this.http.get(full, { headers, responseType: 'blob' }).subscribe({
-      next: blob => {
-        console.log('Blob received, type:', blob.type, 'size:', blob.size);
-        const obj = URL.createObjectURL(blob);
-        this.drawerObjectUrl = obj;
-        this.drawerBlobUrl   = this.sanitizer.bypassSecurityTrustResourceUrl(obj);
-        this.drawerLoading   = false;
-        this.cdr.detectChanges();
-      },
-      error: () => {
-        console.error('Failed to fetch file:', Error);
-
-        this.drawerBlobUrl = this.sanitizer.bypassSecurityTrustResourceUrl(full);
-        this.drawerLoading = false;
-        this.cdr.detectChanges();
-      }
-    });
+  drawerOcr(): OcrResult | null {
+    if (!this.drawerMedia) return null;
+    return this.ocrFor(this.drawerMedia.id);
   }
 
+  /**
+   * Crée un nouveau finding pré‑rempli avec le contenu de la preuve
+   */
+  linkEvidenceToFinding(): void {
+    if (!this.drawerMedia || !this.currentStep) return;
+    if (this.request?.status === 'COMPLETED') return;
+
+    const ocr = this.drawerOcr();
+    const fullText = (ocr?.rawText || '').trim();
+    const fileName = this.displayName(this.drawerMedia.name, this.drawerMediaIndex);
+
+    this.addFinding();
+    const list = this.findings[this.currentStep.id] ?? [];
+    const last = list[list.length - 1];
+    if (last) {
+      last.description = `Evidence: ${fileName}` +
+        (fullText ? `\n\nOCR extracted text:\n${fullText}` : '');
+    }
+    this.flash('Finding created from evidence.', false);
+    this.cdr.detectChanges();
+  }
+
+  /**
+   * Ferme le drawer evidence
+   */
   closeDrawer(): void {
     this.showDrawer = false;
     this.drawerMedia = null;
@@ -902,56 +1072,98 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     this.releaseDrawerBlob();
   }
 
-  setDrawerTab(t: 'preview' | 'ocr'): void {
-    this.drawerTab = t;
-    if (t === 'ocr') this.ensureRelevance();
+  /**
+   * Change l'onglet du drawer evidence (preview / ocr)
+   */
+  setDrawerTab(tab: 'preview' | 'ocr'): void {
+    this.drawerTab = tab;
+    if (tab === 'ocr') this.ensureRelevance();
   }
 
-  /** Toggle relevance shading; fetch semantic scores the first time it's on. */
-  toggleOcrHighlight(): void {
-    this.ocrHighlightOn = !this.ocrHighlightOn;
-    this._ocrHlCache = null;
-    if (this.ocrHighlightOn) this.ensureRelevance();
-  }
+  // ── Evidence Drawer ─────────────────────────────────────────────
+  openEvidence(media: { id: number; url: string; name: string },
+               index = 0,
+               query = '',
+               tab: 'preview' | 'ocr' = 'preview'): void {
 
-  private releaseDrawerBlob(): void {
-    if (this.drawerObjectUrl) {
-      try { URL.revokeObjectURL(this.drawerObjectUrl); } catch { /* noop */ }
-      this.drawerObjectUrl = null;
+    this.releaseDrawerBlob();
+    this.drawerMedia = media;
+    this.drawerMediaIndex = index;
+    this.drawerQuery = query;
+    this.showDrawer = true;
+    this.drawerLoading = true;
+    this.drawerBlobUrl = null;
+    this.drawerTab = tab;
+
+    // 🔹 Cas des fichiers DOCX : on récupère le PDF en blob avec token
+    if (media.name.toLowerCase().endsWith('.docx')) {
+      // 1. Récupérer l'URL du PDF converti
+      const previewUrlEndpoint = `${environment.apiUrl}/media/${media.id}/preview`;
+      const token = this.tokenSvc.getToken();
+      const headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
+
+      this.http.get(previewUrlEndpoint, { headers, responseType: 'text' })
+        .subscribe({
+          next: (pdfPath) => {
+            if (!pdfPath) {
+              this.drawerLoading = false;
+              return;
+            }
+            // 2. Construire l'URL complète du PDF
+            const fullPdfUrl = this.getFileUrl(pdfPath);
+            // 3. Télécharger le PDF en blob avec le token
+            this.http.get(fullPdfUrl, { headers, responseType: 'blob' })
+              .subscribe({
+                next: (blob) => {
+                  const objectUrl = URL.createObjectURL(blob);
+                  this.drawerObjectUrl = objectUrl;
+                  this.drawerBlobUrl = this.sanitizer.bypassSecurityTrustResourceUrl(objectUrl);
+                  this.drawerLoading = false;
+                  this.cdr.detectChanges();
+                },
+                error: (err) => {
+                  log.error(LOG, 'preview PDF load failed', err);
+                  this.drawerLoading = false;
+                  this.cdr.detectChanges();
+                }
+              });
+          },
+          error: (err) => {
+            log.error(LOG, 'preview URL fetch failed', err);
+            this.drawerLoading = false;
+            this.cdr.detectChanges();
+          }
+        });
+      return;
     }
+
+    // 🔹 Pour les autres fichiers (images, PDF) : chargement classique en blob
+    const token = this.tokenSvc.getToken();
+    const headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
+    const full = this.getFileUrl(media.url);
+
+    this.http.get(full, { headers, responseType: 'blob' }).subscribe({
+      next: blob => {
+        const obj = URL.createObjectURL(blob);
+        this.drawerObjectUrl = obj;
+        this.drawerBlobUrl = this.sanitizer.bypassSecurityTrustResourceUrl(obj);
+        this.drawerLoading = false;
+        this.cdr.detectChanges();
+      },
+      error: () => {
+        this.drawerBlobUrl = this.sanitizer.bypassSecurityTrustResourceUrl(full);
+        this.drawerLoading = false;
+        this.cdr.detectChanges();
+      }
+    });
   }
 
-  drawerOcr(): OcrResult | null {
-    return this.drawerMedia ? this.ocrFor(this.drawerMedia.id) : null;
-  }
-
-  /** Seed a new Finding on the current step pre-filled with evidence + OCR snippet. */
-  linkEvidenceToFinding(): void {
-    if (!this.drawerMedia || !this.currentStep) return;
-    if (this.request?.status === 'COMPLETED') return;
-
-    const ocr     = this.drawerOcr();
-    const snippet = (ocr?.rawText || '').trim().slice(0, 280);
-    const tail    = snippet && (ocr?.rawText || '').length > 280 ? '…' : '';
-
-    this.addFinding();
-    const list = this.findings[this.currentStep.id] ?? [];
-    const last = list[list.length - 1];
-    if (last) {
-      last.description = `Evidence: ${this.displayName(this.drawerMedia.name, this.drawerMediaIndex)}` +
-        (snippet ? `\n\nOCR excerpt:\n${snippet}${tail}` : '');
-    }
-    this.flash('Finding seeded from evidence.', false);
-    this.cdr.detectChanges();
-  }
-
-  // ── Phase 4: RICS clause picker ──────────────────────────────────
+  // ── Clause picker ────────────────────────────────────────────────
   openClausePicker(findingId: string): void {
     if (this.request?.status === 'COMPLETED') return;
     this.pickerOpenFor = findingId;
     this.pickerQuery   = '';
     this.pickerResults = [];
-    // Pre-seed with the finding's own description or the step name for context.
     const stepId = this.currentStep?.id;
     if (stepId != null) {
       const f = (this.findings[stepId] ?? []).find(x => x.id === findingId);
@@ -1000,7 +1212,7 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     const f = (this.findings[stepId] ?? []).find(x => x.id === findingId);
     if (!f) return;
     if (!f.clauses) f.clauses = [];
-    if (f.clauses.some(c => c.ruleId === hit.rule_id)) return; // dedupe
+    if (f.clauses.some(c => c.ruleId === hit.rule_id)) return;
     f.clauses.push({
       ruleId:      hit.rule_id,
       section:     hit.payload?.section,
@@ -1019,7 +1231,7 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     this.cdr.detectChanges();
   }
 
-  // ── Phase 5: AI suggestion actions ────────────────────────────────
+  // ── AI suggestions actions ──────────────────────────────────────
   suggestionToFinding(text: string): void {
     if (!this.currentStep || this.request?.status === 'COMPLETED') return;
     this.addFinding();
@@ -1056,23 +1268,9 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return !!this.dismissedSuggestions[id]?.has(text);
   }
 
-  getFileUrl(url: string): string {
-    return `${this.serverBase}${url}`;
-  }
+  // ── AI context ───────────────────────────────────────────────────
+  aiContextProvider = (): string => this.buildAiContext();
 
-  isImage(name: string): boolean {
-    return /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(name);
-  }
-
-  toggleBot(): void { this.botOpen = !this.botOpen; }
-
-  /**
-   * Assemble a compact, text-only snapshot of the audit under review for the
-   * AI assistant: the current step, its customer answers, and any
-   * OCR-extracted evidence text. Passed to <app-audit-bot> so the assistant
-   * can summarise evidence and reason about compliance for THIS audit rather
-   * than answering generically.
-   */
   buildAiContext(): string {
     const r = this.request;
     const step = this.currentStep;
@@ -1124,10 +1322,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return ctx.length > 20000 ? ctx.slice(0, 20000) + '\n…(truncated)' : ctx;
   }
 
-  /** Bound provider handed to the assistant so it always reads fresh state. */
-  aiContextProvider = (): string => this.buildAiContext();
-
-  /** Push an assistant reply into the current step as a finding, recommendation, or note. */
   onAiInsert(e: { target: 'finding' | 'recommendation' | 'note'; text: string }): void {
     const text = (e?.text || '').trim();
     if (!text || !this.currentStep || this.request?.status === 'COMPLETED') return;
@@ -1154,13 +1348,7 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     this.cdr.detectChanges();
   }
 
-  // ── Step-aware AI suggestions (heuristic, client-side stub) ──
-  /**
-   * Suggestions shown in the "AI Suggestions" box. Prefers grounded hints
-   * fetched from the RAG knowledge base (RICS evidence-check, cited to clause
-   * IDs); falls back to lightweight heuristics while loading or if the RAG
-   * service is unreachable.
-   */
+  // ── AI suggestions (from RAG) ──────────────────────────────────
   get currentSuggestions(): string[] {
     const step = this.currentStep;
     if (!step) return [];
@@ -1174,10 +1362,6 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     return !!step && !!this.aiSuggestLoading[step.id] && !this.aiSuggestions[step.id]?.length;
   }
 
-  /**
-   * Fetch grounded, clause-cited suggestions for a step from the RAG service.
-   * Idempotent per step; a failed/empty fetch silently keeps the heuristics.
-   */
   private ensureAiSuggestions(step: WorkspaceStep | null): void {
     if (!step || step.id == null || this.aiSuggestRequested.has(step.id)) return;
     this.aiSuggestRequested.add(step.id);
@@ -1209,11 +1393,8 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
 
   private heuristicSuggestions(step: WorkspaceStep): string[] {
     const name = (step.name || '').toLowerCase();
-    const ansCount = this.request?.answers?.length ?? 0;
     const fileCount = this.evidenceFileCount;
-
     const stepAnsCount = this.currentStepAnswers.length;
-    void ansCount;
     const generic = [
       `Review the ${stepAnsCount} answer${stepAnsCount === 1 ? '' : 's'} mapped to this step for completeness.`,
       fileCount > 0
@@ -1255,82 +1436,99 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     ];
   }
 
-  // ── Evidence helpers ──
-  /**
-   * Answers that belong to the current step.
-   * If the step carries `fieldIds` (intake-form-based), filter by exact membership.
-   * If `fieldIds` is empty (process-step fallback / default step), show all answers.
-   */
+  // ── Answers ──────────────────────────────────────────────────────
   get currentStepAnswers() {
     return this.currentStep ? this.answersForStep(this.currentStep) : [];
   }
 
-  /**
-   * Resolve the customer answers that belong to a given step, pairing main
-   * answers with their supporting notes and evidence files. Returns an empty
-   * array when nothing is mapped — used both to render a step and to decide
-   * whether the step should appear in the workspace at all.
-   */
   answersForStep(step: WorkspaceStep) {
-  const answers = this.request?.answers ?? [];
-  if (!step) return [];
-  if (!step.fieldIds || step.fieldIds.length === 0) return [];
+    const answers = this.request?.answers ?? [];
+    if (!step) return [];
+    if (!step.fieldIds || step.fieldIds.length === 0) return [];
 
-  // Index answers by fieldId so we can walk the step's fields in TEMPLATE
-  // order. Each L2 question is laid out as consecutive fields — the radio
-  // question, its supporting-note textarea, then its evidence FILE field — so
-  // grouping by that order attaches each note/evidence to the question it
-  // actually belongs to. The previous logic filtered the answers into three
-  // arrays and zipped them by index, which shifted a file onto the wrong
-  // question whenever an earlier question had no evidence (e.g. Q3's file
-  // showing under Q1).
-  const byField = new Map<number, any>();
-  for (const a of answers) byField.set(a.fieldId, a);
+    // Index answers by fieldId so we can walk the step's fields in TEMPLATE
+    // order. Each L2 question is laid out as consecutive fields — the radio
+    // question, its supporting-note textarea, then its evidence FILE field — so
+    // grouping by that order attaches each note/evidence to the question it
+    // actually belongs to. The previous logic filtered the answers into three
+    // arrays and zipped them by index, which shifted a file onto the wrong
+    // question whenever an earlier question had no evidence (e.g. Q3's file
+    // showing under Q1).
+    const byField = new Map<number, any>();
+    for (const a of answers) byField.set(a.fieldId, a);
 
-  const classify = (ans: any): 'evidence' | 'note' | 'main' => {
-    const label = (ans.fieldLabel || '').toLowerCase();
-    if (label === 'evidence files') return 'evidence';
-    if (label.includes('response') || label.includes('supporting')) return 'note';
-    return 'main';
-  };
-  const mergeFiles = (target: any, src: any) => {
-    if (src.fileMedia && !target.fileMedia) target.fileMedia = src.fileMedia;
-    if (src.files?.length) target.files = [...(target.files || []), ...src.files];
-  };
+    const classify = (ans: any): 'evidence' | 'note' | 'main' => {
+      const label = (ans.fieldLabel || '').toLowerCase();
+      if (label === 'evidence files') return 'evidence';
+      if (label.includes('response') || label.includes('supporting')) return 'note';
+      return 'main';
+    };
+    const mergeFiles = (target: any, src: any) => {
+      if (src.fileMedia && !target.fileMedia) target.fileMedia = src.fileMedia;
+      if (src.files?.length) target.files = [...(target.files || []), ...src.files];
+    };
 
-  const result: any[] = [];
-  let current: any = null;
+    const result: any[] = [];
+    let current: any = null;
 
-  for (const fieldId of step.fieldIds) {
-    const ans = byField.get(fieldId);
-    if (!ans) continue;
-    const kind = classify(ans);
-    if (kind === 'main' || !current) {
-      // Start a new question block. (A leading note/evidence with no preceding
-      // main is kept as its own block rather than silently dropped.)
-      current = { ...ans };
-      result.push(current);
-    } else if (kind === 'note') {
-      if (ans.answerValue && !current.answerValue?.includes(ans.answerValue)) {
-        current.answerValue = `${current.answerValue || ''}\n\n**Supporting note:** ${ans.answerValue}`;
+    for (const fieldId of step.fieldIds) {
+      const ans = byField.get(fieldId);
+      if (!ans) continue;
+      const kind = classify(ans);
+      if (kind === 'main' || !current) {
+        // Start a new question block. (A leading note/evidence with no preceding
+        // main is kept as its own block rather than silently dropped.)
+        current = { ...ans, collapsed: false };
+        result.push(current);
+      } else if (kind === 'note') {
+        if (ans.answerValue && !current.answerValue?.includes(ans.answerValue)) {
+          current.answerValue = `${current.answerValue || ''}\n\n**Supporting note:** ${ans.answerValue}`;
+        }
+        mergeFiles(current, ans);
+      } else {
+        mergeFiles(current, ans);
       }
-      mergeFiles(current, ans);
-    } else {
-      mergeFiles(current, ans);
     }
+    return result;
   }
 
-  return result;
-}
-  get evidenceFileCount(): number {
-  let total = 0;
-  for (const a of this.currentStepAnswers) {
-    if (a.fileMedia) total++;
-    if (a.files?.length) total += a.files.length;
+  getPreviewUrl(media: { url: string; name: string }): SafeResourceUrl {
+    const fullUrl = this.getFileUrl(media.url);
+    if (this.isOfficeDocument(media.name)) {
+      const viewerUrl = `https://docs.google.com/gview?url=${encodeURIComponent(fullUrl)}&embedded=true`;
+      return this.sanitizer.bypassSecurityTrustResourceUrl(viewerUrl);
+    }
+    return this.sanitizer.bypassSecurityTrustResourceUrl(fullUrl);
   }
-  return total;
-}
-  // ── Quick-insert chip → append snippet to current draft ──
+
+  get evidenceFileCount(): number {
+    let total = 0;
+    for (const a of this.currentStepAnswers) {
+      if (a.fileMedia) total++;
+      if (a.files?.length) total += a.files.length;
+    }
+    return total;
+  }
+
+  // ── Utilities ──────────────────────────────────────────────────
+  getFileUrl(url: string): string {
+    return `${this.serverBase}${url}`;
+  }
+
+  isImage(name: string): boolean {
+    return /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(name);
+  }
+
+  isPdf(name: string): boolean {
+    return /\.pdf$/i.test(name);
+  }
+
+  isOfficeDoc(name: string): boolean {
+    return /\.(docx?|xlsx?|pptx?)$/i.test(name);
+  }
+
+  toggleBot(): void { this.botOpen = !this.botOpen; }
+
   insertSnippet(label: string): void {
     if (!this.currentStep || this.request?.status === 'COMPLETED') return;
     const map: Record<string, string> = {
@@ -1345,10 +1543,14 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
     this.cdr.detectChanges();
   }
 
-  goBack(): void {
-    this.router.navigate(
-      this.isAuditorMode ? ['/auditor/audits'] : ['/admin/audits']
-    );
+  private flash(msg: string, isError: boolean): void {
+    if (isError) {
+      this.saveError = msg;
+      setTimeout(() => { this.saveError = ''; this.cdr.detectChanges(); }, 3500);
+    } else {
+      this.saveMsg = msg;
+      setTimeout(() => { this.saveMsg = ''; this.cdr.detectChanges(); }, 3500);
+    }
   }
 
   revertToDraft(): void {
@@ -1366,155 +1568,4 @@ export class AuditWorkspaceComponent implements OnInit, OnDestroy {
       }
     });
   }
-
-  private flash(msg: string, isError: boolean): void {
-    if (isError) {
-      this.saveError = msg;
-      setTimeout(() => { this.saveError = ''; this.cdr.detectChanges(); }, 3500);
-    } else {
-      this.saveMsg = msg;
-      setTimeout(() => { this.saveMsg = ''; this.cdr.detectChanges(); }, 3500);
-    }
-  }
-
-
-  async goToStep(idx: number): Promise<void> {
-  if (!this.request || this.request?.status === 'COMPLETED') {
-    this.activeStep = idx;
-    this.ensureAiSuggestions(this.currentStep);
-    return;
-  }
-  // Auto-save current step as DRAFT if there's any content or meta
-  if (this.currentStep && this.hasStepContent(this.currentStep.id)) {
-    await this.persistAsync('DRAFT');
-  }
-  this.activeStep = idx;
-  this.ensureAiSuggestions(this.currentStep);
-  this.cdr.detectChanges();
-}
-
-/** True if the step has either a note or any verdict/finding/rec. */
-private hasStepContent(stepId: number): boolean {
-  if ((this.drafts[stepId] ?? '').trim()) return true;
-  if (Object.keys(this.verdicts[stepId] ?? {}).length) return true;
-  if ((this.findings[stepId] ?? []).length) return true;
-  if ((this.recommendations[stepId] ?? []).length) return true;
-  return false;
-}
-
-private persistAsync(status: 'DRAFT' | 'SAVED'): Promise<void> {
-  return new Promise((resolve) => {
-    if (!this.request || !this.currentStep) { resolve(); return; }
-    const step     = this.currentStep;
-    const desc     = this.composeStepBody(step.id);
-    const existing = this.currentResult;
-
-    if (!this.hasStepContent(step.id)) { resolve(); return; }
-
-    const payload = {
-      processStepId: -1,
-      stepName:      step.name,
-      description:   desc,
-      status
-    };
-
-    const obs = existing
-      ? this.resSvc.update(this.request.id, existing.id, payload)
-      : this.resSvc.saveOrUpdate(this.request.id, payload);
-
-    obs.subscribe({
-      next: result => {
-        const idx = this.results.findIndex(r => r.id === result.id);
-        if (idx !== -1) this.results[idx] = result;
-        else this.results.push(result);
-        this.cdr.detectChanges();
-        resolve();
-      },
-      error: () => resolve()
-    });
-  });
-}
-
-private persist(status: 'DRAFT' | 'SAVED'): void {
-  if (!this.request || !this.currentStep) return;
-  this.isSaving = true;
-  const step     = this.currentStep;
-  const desc     = this.composeStepBody(step.id);
-  const existing = this.currentResult;
-
-  const payload = {
-    processStepId: -1,
-    stepName:      step.name,
-    description:   desc,
-    status
-  };
-
-  const obs = existing
-    ? this.resSvc.update(this.request.id, existing.id, payload)
-    : this.resSvc.saveOrUpdate(this.request.id, payload);
-
-  obs.subscribe({
-    next: result => {
-      const idx = this.results.findIndex(r => r.id === result.id);
-      if (idx !== -1) this.results[idx] = result;
-      else this.results.push(result);
-      this.isSaving = false;
-      this.flash(status === 'DRAFT' ? 'Draft saved.' : 'Step saved.', false);
-      this.cdr.detectChanges();
-    },
-    error: () => {
-      this.isSaving = false;
-      this.flash('Failed to save.', true);
-    }
-  });
-}
-
-// ★ Submit: save ALL steps with content, then complete
-submitAudit(): void {
-  if (!this.request) return;
-  log.info(LOG, 'submit audit', { id: this.request.id, steps: this.steps.length });
-  this.isCompleting = true;
-
-  // Save all steps that have content as SAVED
-  const savePromises = this.steps
-    .filter(s => this.hasStepContent(s.id))
-    .map(s => new Promise<void>((resolve) => {
-      const existing = this.results.find(r => r.stepName === s.name);
-      const payload = {
-        processStepId: -1,
-        stepName:      s.name,
-        description:   this.composeStepBody(s.id),
-        status:        'SAVED' as const
-      };
-      const obs = existing
-        ? this.resSvc.update(this.request!.id, existing.id, payload)
-        : this.resSvc.saveOrUpdate(this.request!.id, payload);
-      obs.subscribe({ next: result => {
-        const idx = this.results.findIndex(r => r.id === result.id);
-        if (idx !== -1) this.results[idx] = result;
-        else this.results.push(result);
-        resolve();
-      }, error: () => resolve() });
-    }));
-
-  Promise.all(savePromises).then(() => {
-    const complete$ = this.isAuditorMode
-      ? this.reqSvc.auditorCompleteAudit(this.request!.id)
-      : this.reqSvc.adminCompleteRequest(this.request!.id);
-
-    complete$.subscribe({
-      next: updated => {
-        this.request      = updated;
-        this.isCompleting = false;
-        this.flash('Audit completed successfully!', false);
-        setTimeout(() => this.goBack(), 1500);
-        this.cdr.detectChanges();
-      },
-      error: () => {
-        this.isCompleting = false;
-        this.flash('Failed to complete audit.', true);
-      }
-    });
-  });
-}
 }

--- a/src/app/layout/topbar/topbar.component.scss
+++ b/src/app/layout/topbar/topbar.component.scss
@@ -154,20 +154,35 @@
   }
 
   &__logout {
-    display:flex; align-items:center; gap:7px; padding:8px 14px;
-    // ← DYNAMIC delete/danger color for logout
-    background: color-mix(in srgb, var(--color-btn-delete) 8%, transparent);
-    border: 1px solid color-mix(in srgb, var(--color-btn-delete) 20%, transparent);
-    border-radius: t.$r-md;
-    color: color-mix(in srgb, var(--color-btn-delete) 80%, white);
-    font-family:t.$font-body; font-size:.81rem; font-weight:600;
-    cursor:pointer; transition:all t.$t-fast;
-    svg { width:15px; height:15px; flex-shrink:0; }
-    &:hover {
-      background: color-mix(in srgb, var(--color-btn-delete) 15%, transparent);
-      color: var(--color-btn-delete);
-      border-color: color-mix(in srgb, var(--color-btn-delete) 40%, transparent);
-    }
-    span { @media (max-width:600px){ display:none; } }
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 14px;
+  border-radius: 8px;
+  font-family: t.$font-body;
+  font-size: .8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all .15s ease;
+  white-space: nowrap;
+
+  background: linear-gradient(135deg, #d1fae5, #a7f3d0);
+  border: 1px solid #a7f3d0;
+  color: #065f46;
+  box-shadow: 0 4px 10px rgba(167, 243, 208, 0.2);
+  svg {
+    width: 15px;
+    height: 15px;
+    flex-shrink: 0;
   }
+
+  span {
+    @media (max-width: 600px) { display: none; }
+  }
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba(110, 231, 183, 0.35);
+  }
+}
 }

--- a/src/main/java/com/devteam/aiauditserver/controllers/MediaController.java
+++ b/src/main/java/com/devteam/aiauditserver/controllers/MediaController.java
@@ -1,0 +1,26 @@
+package com.devteam.aiauditserver.controllers;
+
+import com.devteam.aiauditserver.models.File.MediaModel;
+import com.devteam.aiauditserver.repositories.File.MediaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/media")
+public class MediaController {
+
+    @Autowired
+    private MediaRepository mediaRepository;
+
+    @GetMapping("/{id}/preview")
+    public ResponseEntity<String> getPreviewUrl(@PathVariable Long id) {
+        MediaModel media = mediaRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Media not found with id: " + id));
+        String preview = media.getPreviewUrl();
+        if (preview == null || preview.isEmpty()) {
+            preview = media.getUrl(); // fallback
+        }
+        return ResponseEntity.ok(preview);
+    }
+}

--- a/src/main/java/com/devteam/aiauditserver/controllers/admin/ReportController.java
+++ b/src/main/java/com/devteam/aiauditserver/controllers/admin/ReportController.java
@@ -1,0 +1,41 @@
+package com.devteam.aiauditserver.controllers.admin;
+
+import com.devteam.aiauditserver.services.ReportService;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.ByteArrayInputStream;
+
+/**
+ * Generates a downloadable PDF report for a completed audit. JWT auth is
+ * enforced at the HTTP layer (PUBLIC_ENDPOINTS list), like the other
+ * /api/v1/audits endpoints.
+ */
+@RestController
+@RequestMapping("/api/v1/audits")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    public ReportController(ReportService reportService) {
+        this.reportService = reportService;
+    }
+
+    /** Build and stream the audit PDF report. */
+    @GetMapping("/{auditId}/report")
+    public ResponseEntity<InputStreamResource> exportReport(@PathVariable Long auditId) {
+        ByteArrayInputStream pdf = reportService.generateAuditReport(auditId);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_DISPOSITION,
+                "attachment; filename=audit_" + auditId + "_report.pdf");
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(new InputStreamResource(pdf));
+    }
+}

--- a/src/main/java/com/devteam/aiauditserver/models/File/MediaModel.java
+++ b/src/main/java/com/devteam/aiauditserver/models/File/MediaModel.java
@@ -1,13 +1,10 @@
 package com.devteam.aiauditserver.models.File;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
 
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 @Entity
@@ -18,12 +15,16 @@ public class MediaModel implements Serializable {
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     @Column(name = "id")
     private Long id;
+
     @Column(name = "file_name")
     private String name;
+
     @Column(name = "description")
     private String description;
+
     @Column(name = "file_url")
     private String url;
+
     @Column(name = "file_type")
     private String type;
 
@@ -32,11 +33,15 @@ public class MediaModel implements Serializable {
 
     @Column(name = "share")
     private Boolean share;
+
     @Column(name = "file_size")
     private long size;
+
     @Column(name = "timestmp")
     private Date timestmp;
 
+    @Column(name = "preview_url")
+    private String previewUrl;
 
     public MediaModel() {
         this.timestmp = new Date();
@@ -52,18 +57,10 @@ public class MediaModel implements Serializable {
 
     @PreRemove
     public void preRemove() {
-
-
+        // cleanup if needed
     }
 
-
-    public Integer getRange() {
-        return range;
-    }
-
-    public void setRange(Integer range) {
-        this.range = range;
-    }
+    // ─── Getters & Setters ────────────────────────────────────────
 
     public Long getId() {
         return id;
@@ -97,6 +94,22 @@ public class MediaModel implements Serializable {
         this.type = type;
     }
 
+    public Integer getRange() {
+        return range;
+    }
+
+    public void setRange(Integer range) {
+        this.range = range;
+    }
+
+    public Boolean getShare() {
+        return share;
+    }
+
+    public void setShare(Boolean share) {
+        this.share = share;
+    }
+
     public long getSize() {
         return size;
     }
@@ -113,21 +126,19 @@ public class MediaModel implements Serializable {
         this.description = description;
     }
 
-    public Boolean getShare() {
-        return share;
-    }
-
-    public void setShare(Boolean share) {
-        this.share = share;
-    }
-
     public Date getTimestmp() {
         return timestmp;
     }
-
 
     public void setTimestmp(Date timestmp) {
         this.timestmp = timestmp;
     }
 
+    public String getPreviewUrl() {
+        return previewUrl;
+    }
+
+    public void setPreviewUrl(String previewUrl) {
+        this.previewUrl = previewUrl;
+    }
 }

--- a/src/main/java/com/devteam/aiauditserver/repositories/project/AuditRequestAnswerRepository.java
+++ b/src/main/java/com/devteam/aiauditserver/repositories/project/AuditRequestAnswerRepository.java
@@ -4,6 +4,7 @@ import com.devteam.aiauditserver.models.project.AuditRequest.AuditRequestAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +13,6 @@ public interface AuditRequestAnswerRepository
 
     Optional<AuditRequestAnswer> findByAuditRequestIdAndFieldId(
             Long auditRequestId, Long fieldId);
+
+    List<AuditRequestAnswer> findByAuditRequestId(Long auditId);
 }

--- a/src/main/java/com/devteam/aiauditserver/repositories/project/AuditStepResultRepository.java
+++ b/src/main/java/com/devteam/aiauditserver/repositories/project/AuditStepResultRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 @Repository
 public interface AuditStepResultRepository extends JpaRepository<AuditStepResult, Long> {
     List<AuditStepResult> findByAuditRequestIdOrderByCreatedAtAsc(Long requestId);
+    List<AuditStepResult> findByAuditRequestId(Long auditId);
     Optional<AuditStepResult> findByAuditRequestIdAndProcessStepId(
             Long requestId, Long processStepId);
 }

--- a/src/main/java/com/devteam/aiauditserver/services/File/FilesStorageServiceImpl.java
+++ b/src/main/java/com/devteam/aiauditserver/services/File/FilesStorageServiceImpl.java
@@ -9,13 +9,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
-
+import java.util.concurrent.TimeUnit;
 
 @Service
 public class FilesStorageServiceImpl implements FilesStorageService {
@@ -26,8 +28,80 @@ public class FilesStorageServiceImpl implements FilesStorageService {
 
     private static final List<String> FILES_ACCEPTED_TYPE = Arrays.asList(
             "jpeg", "jpg", "png", "svg", "webp", "pdf", "mp4",
-            "docx", "doc", "xlsx", "xls"
+            "doc", "docx", "xls", "xlsx", "ppt", "pptx"
     );
+
+    private static final Map<String, String> MIME_TO_EXTENSION = new HashMap<>();
+    static {
+        MIME_TO_EXTENSION.put("application/msword", "doc");
+        MIME_TO_EXTENSION.put("application/vnd.openxmlformats-officedocument.wordprocessingml.document", "docx");
+        MIME_TO_EXTENSION.put("application/vnd.ms-excel", "xls");
+        MIME_TO_EXTENSION.put("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "xlsx");
+        MIME_TO_EXTENSION.put("application/vnd.ms-powerpoint", "ppt");
+        MIME_TO_EXTENSION.put("application/vnd.openxmlformats-officedocument.presentationml.presentation", "pptx");
+        MIME_TO_EXTENSION.put("application/pdf", "pdf");
+    }
+
+    // Convert a .docx/.doc to PDF (for preview) using LibreOffice headless.
+    private Path convertDocxToPdf(Path docxPath, String directory) throws IOException, InterruptedException {
+        String os = System.getProperty("os.name").toLowerCase();
+        String command = os.contains("win")
+                ? "C:\\Program Files\\LibreOffice\\program\\soffice.exe"
+                : "soffice";
+
+        if (!Files.exists(docxPath)) {
+            throw new IOException("Input file does not exist: " + docxPath);
+        }
+
+        Path outputDir = Paths.get("WebContent/" + directory + "/preview");
+        if (!Files.exists(outputDir)) {
+            Files.createDirectories(outputDir);
+        }
+
+        String fileName = docxPath.getFileName().toString();
+        String baseName = fileName.substring(0, fileName.lastIndexOf('.'));
+        String pdfName = baseName + ".pdf";
+        Path pdfPath = outputDir.resolve(pdfName);
+
+        Files.deleteIfExists(pdfPath);
+
+        ProcessBuilder pb = new ProcessBuilder(
+                command,
+                "--headless",
+                "--convert-to", "pdf",
+                "--outdir", outputDir.toString(),
+                docxPath.toString()
+        );
+        pb.redirectErrorStream(true);
+
+        logger.info("Converting {} to PDF using LibreOffice", docxPath);
+        Process process = pb.start();
+        boolean finished = process.waitFor(120, TimeUnit.SECONDS); // timeout 2 min
+
+        if (!finished) {
+            process.destroyForcibly();
+            throw new RuntimeException("Conversion timed out after 120 seconds");
+        }
+
+        int exitCode = process.exitValue();
+        if (exitCode != 0) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                StringBuilder output = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    output.append(line).append("\n");
+                }
+                throw new RuntimeException("LibreOffice conversion failed with exit code " + exitCode + ": " + output);
+            }
+        }
+
+        if (!Files.exists(pdfPath)) {
+            throw new RuntimeException("PDF was not generated at: " + pdfPath);
+        }
+
+        logger.info("PDF generated successfully: {}", pdfPath);
+        return pdfPath;
+    }
 
     @Override
     public MediaModel save_file(MultipartFile file, String directory) {
@@ -36,8 +110,8 @@ public class FilesStorageServiceImpl implements FilesStorageService {
             //    from the MIME subtype breaks office formats — a .docx arrives
             //    as "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             //    whose subtype is a long vnd.* string that never matches a clean
-            //    extension. Fall back to the MIME subtype only when the filename
-            //    has no extension.
+            //    extension. Only when the filename has no usable extension, fall
+            //    back to a known MIME->extension mapping, then to the raw subtype.
             String original = file.getOriginalFilename();
             String extension = "";
             if (original != null && original.contains(".")) {
@@ -45,7 +119,9 @@ public class FilesStorageServiceImpl implements FilesStorageService {
             }
             if (extension.isEmpty()) {
                 String contentType = file.getContentType();
-                if (contentType != null && contentType.contains("/")) {
+                if (contentType != null && MIME_TO_EXTENSION.containsKey(contentType)) {
+                    extension = MIME_TO_EXTENSION.get(contentType);
+                } else if (contentType != null && contentType.contains("/")) {
                     extension = contentType.substring(contentType.indexOf("/") + 1).toLowerCase(Locale.ROOT);
                 }
             }
@@ -55,36 +131,56 @@ public class FilesStorageServiceImpl implements FilesStorageService {
                 throw new RuntimeException("Format not supported: " + extension);
             }
 
-            // 2. Define the root directory
+            // 2. Enregistrer le fichier physique
             Path root = Paths.get("WebContent/" + directory);
             if (!Files.exists(root)) {
                 Files.createDirectories(root);
             }
 
-            // 3. FIX: Create a unique FILENAME, not a path
-            // Use UUID or just the timestamp. Don't prepend the 'directory' string here.
             String fileName = UUID.randomUUID().toString() + "_" + new Date().getTime() + "." + extension;
-
-            // This resolves to WebContent/GymRequests/IDs/filename.pdf
             Path filepath = root.resolve(fileName);
-
             Files.copy(file.getInputStream(), filepath, StandardCopyOption.REPLACE_EXISTING);
 
-            // 4. Set the URL for the browser
             String browserUrl = "/WebContent/" + directory + "/" + fileName;
 
+            // 3. Créer le MediaModel original
             MediaModel mediaResult = new MediaModel(
                     fileName,
                     browserUrl,
                     file.getContentType(),
                     file.getSize()
             );
+            mediaResult = repository.save(mediaResult);
 
-            return this.repository.save(mediaResult);
+            // 4. Si c'est un .docx, générer le PDF de prévisualisation
+            if ("docx".equals(extension) || "doc".equals(extension)) {
+                logger.info("Démarrage de la conversion pour : {}", fileName);
+                try {
+                    Path pdfPath = convertDocxToPdf(filepath, directory);
+                    String pdfUrl = "/WebContent/" + directory + "/preview/" + pdfPath.getFileName().toString();
+
+                    MediaModel pdfMedia = new MediaModel(
+                            pdfPath.getFileName().toString(),
+                            pdfUrl,
+                            "application/pdf",
+                            Files.size(pdfPath)
+                    );
+                    pdfMedia = repository.save(pdfMedia);
+
+                    mediaResult.setPreviewUrl(pdfMedia.getUrl());
+                    mediaResult = repository.save(mediaResult);
+
+                    logger.info("Preview PDF généré pour {}", fileName);
+                } catch (Exception e) {
+                    logger.error("Échec de la conversion pour {}", fileName, e);
+                    // On ne bloque pas l'upload
+                }
+            }
+
+            return mediaResult;
 
         } catch (Exception e) {
-            // Log the actual cause so you can see if it's an Access Denied or File Not Found issue
-            logger.error("Internal error saving file: ", e);
+            logger.error("Erreur interne lors de la sauvegarde du fichier : ", e);
             throw new RuntimeException("Could not store the file. Error: " + e.getMessage());
         }
     }
@@ -114,6 +210,4 @@ public class FilesStorageServiceImpl implements FilesStorageService {
         }
         return images;
     }
-
-
 }

--- a/src/main/java/com/devteam/aiauditserver/services/ReportService.java
+++ b/src/main/java/com/devteam/aiauditserver/services/ReportService.java
@@ -1,0 +1,369 @@
+package com.devteam.aiauditserver.services;
+
+import com.devteam.aiauditserver.models.File.MediaModel;
+import com.devteam.aiauditserver.models.project.AuditForm.AuditFormTemplate;
+import com.devteam.aiauditserver.models.project.AuditRequest.AuditRequest;
+import com.devteam.aiauditserver.models.project.AuditRequest.AuditRequestAnswer;
+import com.devteam.aiauditserver.models.project.AuditRequest.AuditRequestAnswerFile;
+import com.devteam.aiauditserver.models.project.AuditRequest.AuditStepResult;
+import com.devteam.aiauditserver.repositories.project.AuditRequestRepository;
+import com.devteam.aiauditserver.repositories.project.AuditRequestAnswerRepository;
+import com.devteam.aiauditserver.repositories.project.AuditStepResultRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Chunk;
+import com.lowagie.text.pdf.PdfWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class ReportService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ReportService.class);
+    private static final String META_OPEN = "<!--AUDIT_META_V1:";
+    private static final String META_CLOSE = ":END-->";
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    private AuditRequestRepository auditRequestRepository;
+
+    @Autowired
+    private AuditRequestAnswerRepository answerRepository;
+
+    @Autowired
+    private AuditStepResultRepository stepResultRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public ByteArrayInputStream generateAuditReport(Long auditId) {
+        try {
+            AuditRequest request = auditRequestRepository.findById(auditId)
+                    .orElseThrow(() -> new RuntimeException("Audit not found"));
+
+            List<AuditStepResult> stepResults = stepResultRepository.findByAuditRequestId(auditId);
+
+            // ─── Fetch answers with media eagerly ────────────────────────
+            List<AuditRequestAnswer> answers = fetchAnswersWithMedia(auditId);
+
+            // ─── 1. Build step → field IDs from template ───────────────
+            Map<String, List<Long>> stepFieldIds = buildStepFieldIds(request.getAuditType().name());
+
+            // ─── 2. Sort and deduplicate steps ───────────────────────────
+            stepResults.sort(Comparator.comparing(
+                AuditStepResult::getStepName,
+                Comparator.nullsLast(Comparator.naturalOrder())
+            ));
+
+            Set<String> seenSteps = new HashSet<>();
+            List<AuditStepResult> uniqueSteps = new ArrayList<>();
+            for (AuditStepResult sr : stepResults) {
+                String name = sr.getStepName();
+                if (name == null) {
+                    if (seenSteps.add("__NULL__")) uniqueSteps.add(sr);
+                } else if (seenSteps.add(name)) {
+                    uniqueSteps.add(sr);
+                }
+            }
+            stepResults = uniqueSteps;
+
+            // ─── 3. Build answer index by fieldId ────────────────────────
+            Map<Long, AuditRequestAnswer> answersByFieldId = new HashMap<>();
+            for (AuditRequestAnswer ans : answers) {
+                answersByFieldId.put(ans.getFieldId(), ans);
+            }
+
+            // ─── 4. PDF creation ─────────────────────────────────────────
+            Document document = new Document(PageSize.A4);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            PdfWriter.getInstance(document, out);
+            document.open();
+
+            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18);
+            Paragraph title = new Paragraph("Audit Report", titleFont);
+            title.setAlignment(Element.ALIGN_CENTER);
+            document.add(title);
+            document.add(new Paragraph(" "));
+
+            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 10);
+            Font boldFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 11);
+            Font italicFont = FontFactory.getFont(FontFactory.HELVETICA_OBLIQUE, 9);
+
+            String company = "N/A";
+            if (request.getSubmittedBy() != null && request.getSubmittedBy().getCompanyInfo() != null) {
+                company = request.getSubmittedBy().getCompanyInfo().getCompanyName();
+            }
+            document.add(new Paragraph("Audit ID: " + request.getId(), normalFont));
+            document.add(new Paragraph("Company: " + company, normalFont));
+            document.add(new Paragraph("Type: " + request.getAuditType(), normalFont));
+            document.add(new Paragraph("Status: " + request.getStatus(), normalFont));
+            document.add(new Paragraph("Generated: " + new SimpleDateFormat("yyyy-MM-dd HH:mm").format(new Date()), normalFont));
+            document.add(new Paragraph(" "));
+            document.add(new Chunk("--------------------------------------------------"));
+
+            // ─── 5. Loop over each step ───────────────────────────────────
+            for (AuditStepResult stepResult : stepResults) {
+                document.add(new Paragraph(" "));
+                Font stepFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14);
+                Paragraph stepTitle = new Paragraph("Step: " + stepResult.getStepName(), stepFont);
+                document.add(stepTitle);
+
+                String rawDescription = stepResult.getDescription() != null ? stepResult.getDescription() : "";
+                String description = cleanDescription(rawDescription);
+                StepMeta meta = parseStepMeta(description);
+                String note = extractNote(description);
+                // Also clean the note itself
+                if (note != null) note = cleanDescription(note);
+
+                if (note != null && !note.isEmpty()) {
+                    document.add(new Paragraph("Note: " + note, normalFont));
+                }
+
+                // ─── Get all field IDs for this step from template ────────
+                List<Long> fieldIds = stepFieldIds.getOrDefault(stepResult.getStepName(), new ArrayList<>());
+                if (fieldIds.isEmpty()) {
+                    fieldIds = new ArrayList<>(meta.verdicts.keySet());
+                }
+                Collections.sort(fieldIds);
+
+                if (fieldIds.isEmpty()) {
+                    document.add(new Paragraph("No questions mapped to this step.", italicFont));
+                    document.add(new Paragraph(" "));
+                    document.add(new Chunk("---"));
+                    continue;
+                }
+
+                document.add(new Paragraph("Questions & Answers", boldFont));
+                document.add(new Paragraph(" "));
+
+                for (Long fieldId : fieldIds) {
+                    AuditRequestAnswer answer = answersByFieldId.get(fieldId);
+                    if (answer == null) continue;
+
+                    String questionLabel = answer.getFieldLabel() != null ? answer.getFieldLabel() : "Question " + fieldId;
+                    String answerValue = answer.getAnswerValue() != null ? answer.getAnswerValue() : "—";
+                    String verdict = meta.verdicts.getOrDefault(fieldId, "N/A");
+
+                    document.add(new Paragraph(questionLabel, boldFont));
+                    document.add(new Paragraph("Answer: " + answerValue, normalFont));
+                    document.add(new Paragraph("Verdict: " + verdict, normalFont));
+
+                    // ─── Evidence with file names ──────────────────────────
+                    List<MediaModel> evidences = getEvidenceForAnswer(answer);
+                    if (!evidences.isEmpty()) {
+                        document.add(new Paragraph("Evidence:", italicFont));
+                        for (MediaModel ev : evidences) {
+                            String fileName = ev.getName();
+                            if (fileName == null || fileName.trim().isEmpty()) {
+                                fileName = "Evidence #" + ev.getId();
+                            }
+                            document.add(new Paragraph("  - " + fileName, normalFont));
+                        }
+                    }
+                    document.add(new Paragraph(" "));
+                }
+
+                // ─── Findings ──────────────────────────────────────────────
+                if (!meta.findings.isEmpty()) {
+                    document.add(new Paragraph("Findings", boldFont));
+                    for (Finding f : meta.findings) {
+                        document.add(new Paragraph("• Severity: " + f.severity, normalFont));
+                        document.add(new Paragraph("  " + f.description, normalFont));
+                        if (f.note != null && !f.note.isEmpty()) {
+                            document.add(new Paragraph("  Note: " + f.note, italicFont));
+                        }
+                        document.add(new Paragraph(" "));
+                    }
+                }
+
+                // ─── Recommendations ──────────────────────────────────────
+                if (!meta.recommendations.isEmpty()) {
+                    document.add(new Paragraph("Recommendations", boldFont));
+                    for (Recommendation r : meta.recommendations) {
+                        document.add(new Paragraph("• " + r.description, normalFont));
+                        document.add(new Paragraph(" "));
+                    }
+                }
+
+                document.add(new Paragraph(" "));
+                document.add(new Chunk("---"));
+            }
+
+            document.add(new Paragraph(" "));
+            Paragraph footer = new Paragraph("End of report - Generated by Compliance Engine", normalFont);
+            footer.setAlignment(Element.ALIGN_CENTER);
+            document.add(footer);
+
+            document.close();
+            return new ByteArrayInputStream(out.toByteArray());
+
+        } catch (Exception e) {
+            logger.error("Error generating PDF report for audit " + auditId, e);
+            throw new RuntimeException("Failed to generate report: " + e.getMessage(), e);
+        }
+    }
+
+    // ─── Fetch answers with media eagerly ──────────────────────────────
+    private List<AuditRequestAnswer> fetchAnswersWithMedia(Long auditId) {
+        String jpql = "SELECT a FROM AuditRequestAnswer a " +
+                      "LEFT JOIN FETCH a.fileMedia " +
+                      "LEFT JOIN FETCH a.files f " +
+                      "LEFT JOIN FETCH f.media " +
+                      "WHERE a.auditRequest.id = :auditId";
+        return entityManager.createQuery(jpql, AuditRequestAnswer.class)
+                .setParameter("auditId", auditId)
+                .getResultList();
+    }
+
+    // ─── Build step → field IDs from template using EntityManager ────
+    private Map<String, List<Long>> buildStepFieldIds(String auditType) {
+        Map<String, List<Long>> map = new LinkedHashMap<>();
+        try {
+            String jpql = "SELECT t FROM AuditFormTemplate t WHERE t.auditType = :auditType";
+            List<AuditFormTemplate> templates = entityManager.createQuery(jpql, AuditFormTemplate.class)
+                    .setParameter("auditType", auditType)
+                    .getResultList();
+
+            if (!templates.isEmpty()) {
+                AuditFormTemplate template = templates.get(0);
+                if (template.getSteps() != null) {
+                    for (var step : template.getSteps()) {
+                        String stepName = step.getTitle();
+                        List<Long> fieldIds = step.getFields() != null
+                                ? step.getFields().stream().map(f -> f.getId()).collect(Collectors.toList())
+                                : new ArrayList<>();
+                        map.put(stepName, fieldIds);
+                    }
+                }
+            } else {
+                logger.warn("No template found for audit type '{}' – using verdict keys as fallback", auditType);
+            }
+        } catch (Exception e) {
+            logger.warn("Could not retrieve template for audit type '{}' – using verdict keys as fallback", auditType, e);
+        }
+        return map;
+    }
+
+    // ─── Clean OCR artifacts (removes lines with text[[...]]) ────────
+    private String cleanDescription(String description) {
+        if (description == null) return "";
+        return description.replaceAll("(?m)^.*text\\[\\[.*?\\]\\].*$", "").trim();
+    }
+
+    // ===== INNER CLASSES =====
+    private static class StepMeta {
+        Map<Long, String> verdicts = new HashMap<>();
+        List<Finding> findings = new ArrayList<>();
+        List<Recommendation> recommendations = new ArrayList<>();
+    }
+
+    @SuppressWarnings("unused")
+    private static class Finding {
+        String id;
+        String severity;
+        String description;
+        String note;
+    }
+
+    @SuppressWarnings("unused")
+    private static class Recommendation {
+        String id;
+        String description;
+    }
+
+    // ===== PARSING =====
+    private StepMeta parseStepMeta(String description) {
+        StepMeta meta = new StepMeta();
+        int openIdx = description.indexOf(META_OPEN);
+        if (openIdx == -1) return meta;
+        int closeIdx = description.indexOf(META_CLOSE, openIdx + META_OPEN.length());
+        if (closeIdx == -1) return meta;
+
+        String json = description.substring(openIdx + META_OPEN.length(), closeIdx);
+        try {
+            Map<String, Object> root = objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+
+            Object verdictsObj = root.get("verdicts");
+            if (verdictsObj instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, String> vMap = (Map<String, String>) verdictsObj;
+                for (Map.Entry<String, String> entry : vMap.entrySet()) {
+                    try {
+                        meta.verdicts.put(Long.parseLong(entry.getKey()), entry.getValue());
+                    } catch (NumberFormatException e) {
+                        logger.warn("Skipping verdict with non-numeric key: {}", entry.getKey());
+                    }
+                }
+            }
+
+            Object findingsObj = root.get("findings");
+            if (findingsObj instanceof List) {
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> fList = (List<Map<String, Object>>) findingsObj;
+                for (Map<String, Object> fMap : fList) {
+                    Finding f = new Finding();
+                    f.id = (String) fMap.get("id");
+                    f.severity = (String) fMap.get("severity");
+                    f.description = (String) fMap.get("description");
+                    f.note = (String) fMap.get("note");
+                    meta.findings.add(f);
+                }
+            }
+
+            Object recsObj = root.get("recommendations");
+            if (recsObj instanceof List) {
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> rList = (List<Map<String, Object>>) recsObj;
+                for (Map<String, Object> rMap : rList) {
+                    Recommendation r = new Recommendation();
+                    r.id = (String) rMap.get("id");
+                    r.description = (String) rMap.get("description");
+                    meta.recommendations.add(r);
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to parse step meta: " + e.getMessage());
+        }
+        return meta;
+    }
+
+    private String extractNote(String description) {
+        int openIdx = description.indexOf(META_OPEN);
+        if (openIdx == -1) return description.trim();
+        int closeIdx = description.indexOf(META_CLOSE, openIdx + META_OPEN.length());
+        if (closeIdx == -1) return description.trim();
+        String note = (description.substring(0, openIdx) + description.substring(closeIdx + META_CLOSE.length())).trim();
+        return note.isEmpty() ? null : note;
+    }
+
+    private List<MediaModel> getEvidenceForAnswer(AuditRequestAnswer answer) {
+        List<MediaModel> evidences = new ArrayList<>();
+        if (answer.getFileMedia() != null) {
+            evidences.add(answer.getFileMedia());
+        }
+        if (answer.getFiles() != null) {
+            for (AuditRequestAnswerFile file : answer.getFiles()) {
+                if (file.getMedia() != null) {
+                    evidences.add(file.getMedia());
+                }
+            }
+        }
+        return evidences;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,9 @@ spring:
       enabled: true
   main:
     allow-bean-definition-overriding: true
+  security:
+    headers:
+      frame: false
   mail:
     host: smtp.gmail.com
     port: 587
@@ -48,6 +51,7 @@ spring:
       matching-strategy: ant_path_matcher
   flyway:
     enabled: false
+
 server:
   port: ${PORT:8080}
   error:


### PR DESCRIPTION
Integrates the audit-workspace work from two diverged feature branches onto current `develop`, fully reconciled and verified.

## What's included
- **UI rework** (`feature/ticket-15-ui-style`): responsive audit-workspace + topbar, collapsible step rail and questions, finding note field, OCR relevance highlighting, Word/Office document preview (LibreOffice PDF conversion) + Office upload types.
- **PDF report** (ported from `feature/generate-pdf-report`): server-side `ReportService` (OpenPDF) + `ReportController` `GET /api/v1/audits/{id}/report`, Export PDF button, collapsible Findings & Recommendations drawer.
- **Verdict validation**: Next button disabled until every question on a step has a verdict.

## Reconciliation notes
- Preserves develop's evidence-per-question (`answersForStep`) and Complete-button fixes; drops the duplicated docx implementation in favour of develop's.
- `feature/generate-pdf-report` forked from the project root and could not be merged by history (missing ~150 backend files), so its PDF feature was **ported** surgically, not merged. `ReportService` reconciled against develop's current models (Spring Boot 2.5.6 / `javax.persistence`).
- Cleanups: removed a UTF-8 BOM and debug `console.*`; converted `console.error` to the project logger; theme variables instead of hardcoded colours.

## Verification
- Backend `mvn compile` (with OpenPDF) — pass
- Frontend `tsc --noEmit` — pass
- Pre-commit hooks (mojibake/BOM, EOF, trailing whitespace) — pass
- Chatbot verified working end-to-end locally (persist → RAG context → reply → insert)

Suggest **squash-merge** to collapse the validation feature's commits into one.
